### PR TITLE
Provider-Id AVP

### DIFF
--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -470,6 +470,7 @@ const (
 	PriorityLevel                              = 1046
 	ProductName                                = 269
 	Prompt                                     = 76
+	ProviderID                                 = 10001
 	ProxyHost                                  = 280
 	ProxyInfo                                  = 284
 	ProxyState                                 = 33

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -563,9 +563,14 @@ var baseXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<item code="15" name="PRIORITY_15"/>
 			</data>
 		</avp>
-		</application>
-		<application id="3" type="acct" name="Base Accounting"> <!-- Diameter Base Accounting Messages -->
 
+        <avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
+			<data type="OctetString"/>
+		</avp>
+
+
+	</application>
+	<application id="3" type="acct" name="Base Accounting"> <!-- Diameter Base Accounting Messages -->
 	</application>
 </diameter>`
 

--- a/diam/dict/testdata/base.xml
+++ b/diam/dict/testdata/base.xml
@@ -522,6 +522,10 @@
 			</data>
 		</avp>
 
+        <avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
+			<data type="OctetString"/>
+		</avp>
+
 
 	</application>
 	<application id="3" type="acct" name="Base Accounting"> <!-- Diameter Base Accounting Messages -->


### PR DESCRIPTION
We need this for Gx. We have a custom Provider-Id AVP for sy, this PR adds the AVP to the base dictionary so it can be used anywhere we need in the future.