### PR TITLE
CEA: advertise only supported apps and select PCRF identity for Gx/Rx

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -134,7 +134,10 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	// Fix for Same H2H and E2E Identifier in success response
 	a.Header.HopByHopID = m.Header.HopByHopID
 	a.Header.EndToEndID = m.Header.EndToEndID
-	originHost, originRealm := ceaIdentity(sm, cer.Applications())
+	originHost, originRealm := sm.cfg.OriginHost, sm.cfg.OriginRealm
+	if len(sm.cfg.PcrfHost) > 0 && len(sm.cfg.PcrfRealm) > 0 && requestsOnlyPcrfApps(cer.Applications()) {
+		originHost, originRealm = sm.cfg.PcrfHost, sm.cfg.PcrfRealm
+	}
 	a.NewAVP(avp.OriginHost, avp.Mbit, 0, originHost)
 	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, originRealm)
 	for _, hostAddress := range hostAddresses {
@@ -146,7 +149,7 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 		a.AddAVP(cer.OriginStateID)
 	}
 	for _, app := range sm.supportedApps {
-		if !isCEAAdvertisedApp(app.ID) {
+		if !ceaAdvertisedApps[app.ID] {
 			continue
 		}
 		var typ uint32
@@ -178,34 +181,19 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	})(c, a)
 }
 
-// isCEAAdvertisedApp reports whether an application is advertised in the CEA.
-// Only the applications this adapter actually supports are advertised; every
-// other application present in the loaded dictionary is omitted.
-func isCEAAdvertisedApp(id uint32) bool {
-	switch id {
-	case diam.CHARGING_CONTROL_APP_ID, // Gy (4)
-		diam.RX_APP_ID,                  // Rx (16777236)
-		diam.GX_CHARGING_CONTROL_APP_ID, // Gx (16777238)
-		diam.DIAMETER_SY_APP_ID:         // Sy (16777302)
-		return true
-	}
-	return false
+// ceaAdvertisedApps is the set of applications this adapter supports and
+// therefore advertises in the CEA; every other application in the dictionary
+// is omitted.
+var ceaAdvertisedApps = map[uint32]bool{
+	diam.CHARGING_CONTROL_APP_ID:    true, // Gy
+	diam.RX_APP_ID:                  true, // Rx
+	diam.GX_CHARGING_CONTROL_APP_ID: true, // Gx
+	diam.DIAMETER_SY_APP_ID:         true, // Sy
 }
 
-// ceaIdentity selects the Origin-Host/Origin-Realm for the CEA. When PcrfHost
-// and PcrfRealm are configured and the CER requests exclusively Gx and/or Rx
-// applications, the PCRF identity is advertised; otherwise the default
-// OriginHost/OriginRealm is used.
-func ceaIdentity(sm *StateMachine, requestedApps []uint32) (datatype.DiameterIdentity, datatype.DiameterIdentity) {
-	if len(sm.cfg.PcrfHost) > 0 && len(sm.cfg.PcrfRealm) > 0 && onlyPcrfApps(requestedApps) {
-		return sm.cfg.PcrfHost, sm.cfg.PcrfRealm
-	}
-	return sm.cfg.OriginHost, sm.cfg.OriginRealm
-}
-
-// onlyPcrfApps reports whether the requested applications are non-empty and
-// consist exclusively of Gx and/or Rx.
-func onlyPcrfApps(requestedApps []uint32) bool {
+// requestsOnlyPcrfApps reports whether the CER requested applications and every
+// one of them is Gx or Rx.
+func requestsOnlyPcrfApps(requestedApps []uint32) bool {
 	if len(requestedApps) == 0 {
 		return false
 	}

--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -134,8 +134,9 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	// Fix for Same H2H and E2E Identifier in success response
 	a.Header.HopByHopID = m.Header.HopByHopID
 	a.Header.EndToEndID = m.Header.EndToEndID
-	a.NewAVP(avp.OriginHost, avp.Mbit, 0, sm.cfg.OriginHost)
-	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, sm.cfg.OriginRealm)
+	originHost, originRealm := ceaIdentity(sm, cer.Applications())
+	a.NewAVP(avp.OriginHost, avp.Mbit, 0, originHost)
+	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, originRealm)
 	for _, hostAddress := range hostAddresses {
 		a.NewAVP(avp.HostIPAddress, avp.Mbit, 0, hostAddress)
 	}
@@ -145,6 +146,9 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 		a.AddAVP(cer.OriginStateID)
 	}
 	for _, app := range sm.supportedApps {
+		if !isCEAAdvertisedApp(app.ID) {
+			continue
+		}
 		var typ uint32
 		switch app.AppType {
 		case "auth":
@@ -172,4 +176,43 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 		_, err = answer.WriteTo(conn)
 		return err
 	})(c, a)
+}
+
+// isCEAAdvertisedApp reports whether an application is advertised in the CEA.
+// Only the applications this adapter actually supports are advertised; every
+// other application present in the loaded dictionary is omitted.
+func isCEAAdvertisedApp(id uint32) bool {
+	switch id {
+	case diam.CHARGING_CONTROL_APP_ID, // Gy (4)
+		diam.RX_APP_ID,                  // Rx (16777236)
+		diam.GX_CHARGING_CONTROL_APP_ID, // Gx (16777238)
+		diam.DIAMETER_SY_APP_ID:         // Sy (16777302)
+		return true
+	}
+	return false
+}
+
+// ceaIdentity selects the Origin-Host/Origin-Realm for the CEA. When PcrfHost
+// and PcrfRealm are configured and the CER requests exclusively Gx and/or Rx
+// applications, the PCRF identity is advertised; otherwise the default
+// OriginHost/OriginRealm is used.
+func ceaIdentity(sm *StateMachine, requestedApps []uint32) (datatype.DiameterIdentity, datatype.DiameterIdentity) {
+	if len(sm.cfg.PcrfHost) > 0 && len(sm.cfg.PcrfRealm) > 0 && onlyPcrfApps(requestedApps) {
+		return sm.cfg.PcrfHost, sm.cfg.PcrfRealm
+	}
+	return sm.cfg.OriginHost, sm.cfg.OriginRealm
+}
+
+// onlyPcrfApps reports whether the requested applications are non-empty and
+// consist exclusively of Gx and/or Rx.
+func onlyPcrfApps(requestedApps []uint32) bool {
+	if len(requestedApps) == 0 {
+		return false
+	}
+	for _, id := range requestedApps {
+		if id != diam.GX_CHARGING_CONTROL_APP_ID && id != diam.RX_APP_ID {
+			return false
+		}
+	}
+	return true
 }

--- a/diam/sm/cer_cea_pcrf_test.go
+++ b/diam/sm/cer_cea_pcrf_test.go
@@ -1,0 +1,194 @@
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package sm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/diamtest"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+)
+
+// pcrfServerSettings advertises a distinct PCRF identity so the CEA identity
+// selection can be observed on the wire.
+var pcrfServerSettings = &Settings{
+	OriginHost:       "ocs.example.com",
+	OriginRealm:      "ocs-realm.example.com",
+	VendorID:         13,
+	ProductName:      "go-diameter",
+	OriginStateID:    datatype.Unsigned32(1),
+	FirmwareRevision: 1,
+	PcrfHost:         "pcrf.example.com",
+	PcrfRealm:        "pcrf-realm.example.com",
+}
+
+// advertisedAppIDs collects every application id advertised in a CEA, both the
+// top-level Auth/Acct-Application-Id AVPs and the ones nested inside grouped
+// Vendor-Specific-Application-Id AVPs.
+func advertisedAppIDs(t *testing.T, m *diam.Message) map[uint32]bool {
+	t.Helper()
+	ids := map[uint32]bool{}
+	for _, a := range m.AVP {
+		switch a.Code {
+		case avp.AuthApplicationID, avp.AcctApplicationID:
+			ids[uint32(a.Data.(datatype.Unsigned32))] = true
+		case avp.VendorSpecificApplicationID:
+			grouped, ok := a.Data.(*diam.GroupedAVP)
+			if !ok {
+				continue
+			}
+			for _, inner := range grouped.AVP {
+				if inner.Code == avp.AuthApplicationID || inner.Code == avp.AcctApplicationID {
+					ids[uint32(inner.Data.(datatype.Unsigned32))] = true
+				}
+			}
+		}
+	}
+	return ids
+}
+
+// originIdentity returns the Origin-Host/Origin-Realm advertised in a CEA.
+func originIdentity(t *testing.T, m *diam.Message) (string, string) {
+	t.Helper()
+	var host, realm string
+	for _, a := range m.AVP {
+		switch a.Code {
+		case avp.OriginHost:
+			host = string(a.Data.(datatype.DiameterIdentity))
+		case avp.OriginRealm:
+			realm = string(a.Data.(datatype.DiameterIdentity))
+		}
+	}
+	return host, realm
+}
+
+// exchangeCER sends a CER advertising the given application ids (as top-level
+// Auth-Application-Id AVPs) and returns the CEA the server answers with.
+func exchangeCER(t *testing.T, settings *Settings, appIDs ...uint32) *diam.Message {
+	t.Helper()
+	sm := New(settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	mc := make(chan *diam.Message, 1)
+	mux := diam.NewServeMux()
+	mux.HandleFunc("CEA", func(c diam.Conn, m *diam.Message) {
+		mc <- m
+	})
+	cli, err := diam.Dial(srv.Addr, mux, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	for _, id := range appIDs {
+		m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(id))
+	}
+	if _, err = m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case resp := <-mc:
+		return resp
+	case err := <-mux.ErrorReports():
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("No CEA received")
+	}
+	return nil
+}
+
+// TestCEA_AdvertisesOnlySupportedApps verifies that the CEA advertises only the
+// four applications this adapter supports (Gy, Rx, Gx, Sy), even though the
+// loaded dictionary contains more applications (NASREQ, Base Accounting, S6a,
+// SWx).
+func TestCEA_AdvertisesOnlySupportedApps(t *testing.T) {
+	cea := exchangeCER(t, pcrfServerSettings, diam.GX_CHARGING_CONTROL_APP_ID)
+	if !testResultCode(cea, diam.Success) {
+		t.Fatalf("Unexpected result code.\n%s", cea)
+	}
+
+	got := advertisedAppIDs(t, cea)
+	want := map[uint32]bool{
+		diam.CHARGING_CONTROL_APP_ID:    true,
+		diam.RX_APP_ID:                  true,
+		diam.GX_CHARGING_CONTROL_APP_ID: true,
+		diam.DIAMETER_SY_APP_ID:         true,
+	}
+	for id := range want {
+		if !got[id] {
+			t.Errorf("CEA missing supported application id %d", id)
+		}
+	}
+	for id := range got {
+		if !want[id] {
+			t.Errorf("CEA advertises unsupported application id %d", id)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("CEA advertised %d apps, want %d (%v)", len(got), len(want), got)
+	}
+}
+
+// TestCEA_PcrfIdentitySelection verifies the Origin-Host/Origin-Realm chosen in
+// the CEA based on the applications requested in the CER.
+func TestCEA_PcrfIdentitySelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		appIDs    []uint32
+		wantHost  string
+		wantRealm string
+	}{
+		{"gx only", []uint32{diam.GX_CHARGING_CONTROL_APP_ID}, "pcrf.example.com", "pcrf-realm.example.com"},
+		{"rx only", []uint32{diam.RX_APP_ID}, "pcrf.example.com", "pcrf-realm.example.com"},
+		{"gx and rx", []uint32{diam.GX_CHARGING_CONTROL_APP_ID, diam.RX_APP_ID}, "pcrf.example.com", "pcrf-realm.example.com"},
+		{"gy only", []uint32{diam.CHARGING_CONTROL_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
+		{"sy only", []uint32{diam.DIAMETER_SY_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
+		{"gx and gy", []uint32{diam.GX_CHARGING_CONTROL_APP_ID, diam.CHARGING_CONTROL_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cea := exchangeCER(t, pcrfServerSettings, tc.appIDs...)
+			if !testResultCode(cea, diam.Success) {
+				t.Fatalf("Unexpected result code.\n%s", cea)
+			}
+			host, realm := originIdentity(t, cea)
+			if host != tc.wantHost {
+				t.Errorf("Origin-Host = %q, want %q", host, tc.wantHost)
+			}
+			if realm != tc.wantRealm {
+				t.Errorf("Origin-Realm = %q, want %q", realm, tc.wantRealm)
+			}
+		})
+	}
+}
+
+// TestCEA_NoPcrfConfigUsesDefaultIdentity verifies that when PcrfHost/PcrfRealm
+// are unset, a Gx CER still gets the default Origin-Host/Origin-Realm.
+func TestCEA_NoPcrfConfigUsesDefaultIdentity(t *testing.T) {
+	cea := exchangeCER(t, serverSettings, diam.GX_CHARGING_CONTROL_APP_ID)
+	if !testResultCode(cea, diam.Success) {
+		t.Fatalf("Unexpected result code.\n%s", cea)
+	}
+	host, realm := originIdentity(t, cea)
+	if host != string(serverSettings.OriginHost) {
+		t.Errorf("Origin-Host = %q, want %q", host, serverSettings.OriginHost)
+	}
+	if realm != string(serverSettings.OriginRealm) {
+		t.Errorf("Origin-Realm = %q, want %q", realm, serverSettings.OriginRealm)
+	}
+}

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -53,10 +53,8 @@ type Settings struct {
 	VendorID    datatype.Unsigned32
 	ProductName datatype.UTF8String
 
-	// PcrfHost and PcrfRealm are advertised as Origin-Host/Origin-Realm in the
-	// CEA when the peer's CER requests only Gx and/or Rx applications. When set
-	// and the CER requests exclusively Gx/Rx, these replace OriginHost/OriginRealm
-	// in the successful CEA. When unset, OriginHost/OriginRealm are always used.
+	// PcrfHost and PcrfRealm, when set, are advertised as Origin-Host/Origin-Realm
+	// in the CEA if the CER requests only Gx and/or Rx.
 	PcrfHost  datatype.DiameterIdentity
 	PcrfRealm datatype.DiameterIdentity
 

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -53,6 +53,13 @@ type Settings struct {
 	VendorID    datatype.Unsigned32
 	ProductName datatype.UTF8String
 
+	// PcrfHost and PcrfRealm are advertised as Origin-Host/Origin-Realm in the
+	// CEA when the peer's CER requests only Gx and/or Rx applications. When set
+	// and the CER requests exclusively Gx/Rx, these replace OriginHost/OriginRealm
+	// in the successful CEA. When unset, OriginHost/OriginRealm are always used.
+	PcrfHost  datatype.DiameterIdentity
+	PcrfRealm datatype.DiameterIdentity
+
 	// OriginStateID is optional for clients, and not added if unset.
 	//
 	// On servers it has no effect because CEA will contain the

--- a/diam/sm/sm_test.go
+++ b/diam/sm/sm_test.go
@@ -35,7 +35,7 @@ func TestStateMachineTCP(t *testing.T) {
 	testStateMachine(t, "tcp")
 }
 
-/// TestStateMachine establishes a connection with a test server and
+// / TestStateMachine establishes a connection with a test server and
 // sends a Re-Auth-Request message to ensure the handshake was
 // completed and that the RAR handler has context from the peer.
 func testStateMachine(t *testing.T, network string) {
@@ -103,7 +103,7 @@ func testStateMachine(t *testing.T, network string) {
 
 		expectedCea := strings.TrimSpace(fmt.Sprintf(`
 Capabilities-Exchange-Answer (CEA)
-{Code:257,Flags:0x0,Version:0x1,Length:452,ApplicationId:1001,HopByHopId:0x%x,EndToEndId:0x%x}
+{Code:257,Flags:0x0,Version:0x1,Length:316,ApplicationId:1001,HopByHopId:0x%x,EndToEndId:0x%x}
 	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
 	Origin-Host {Code:264,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{srv},Padding:1}
 	Origin-Realm {Code:296,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{test},Padding:0}
@@ -111,14 +111,12 @@ Capabilities-Exchange-Answer (CEA)
 	Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{13}}
 	Product-Name {Code:269,Flags:0x0,Length:20,VendorId:0,Value:UTF8String{go-diameter},Padding:1}
 	Origin-State-Id {Code:278,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1}}
-	Acct-Application-Id {Code:259,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{3}}
 	Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{4}}
 	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
 	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
 		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777238}},
 	}}
-	Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1}}
 	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
 	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
@@ -132,20 +130,8 @@ Capabilities-Exchange-Answer (CEA)
 	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
 	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777251}},
-	}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777265}},
-	}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
 		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777302}},
 	}}
-	Acct-Application-Id {Code:259,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1001}}
-	Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1002}}
 	Firmware-Revision {Code:267,Flags:0x0,Length:12,VendorId:0,Value:Unsigned32{1}}
 
 			`, resp.Header.HopByHopID, resp.Header.EndToEndID))


### PR DESCRIPTION
## What

Two fixes to the server-side CER/CEA capabilities exchange (`diam/sm/cer.go` `successCEA`):

1. **Advertise only supported applications.** The CEA looped over every application loaded into `dict.Default` and advertised all of them — NASREQ (1), Base Accounting (3), S6a (16777251), SWx (16777265) included. It now advertises only the four this adapter supports: Gy (4), Rx (16777236), Gx (16777238), Sy (16777302), via the `ceaAdvertisedApps` set.

2. **PCRF identity selection.** New `Settings.PcrfHost` / `Settings.PcrfRealm`. When both are set and the peer's CER requests **exclusively** Gx and/or Rx, the CEA advertises the PCRF identity as Origin-Host/Origin-Realm; otherwise it keeps the default `OriginHost`/`OriginRealm`. Unset = unchanged behaviour.

`errorCEA` is intentionally left on the default identity — the CER is unparsed on the error path, so there are no requested apps to key on.

## Why filter the advertised set instead of trimming the dictionary

`dict.Default` serves two distinct jobs: it builds the CEA advertised-app list **and** it is the dictionary used to decode incoming AVPs. The two sets cannot be made equal, because decode relies on a hierarchical fallback (`parentAppIds` in `diam/dict/util.go`: `Gx(16777238) -> 4 -> 1`). NASREQ (app 1) is therefore a decode-parent of Gx — a Gx CCR inherits IP-CAN AVP definitions (e.g. Framed-IP-Address, Framed-IPv6-Prefix, Called-Station-Id) from it. Unloading NASREQ would silently degrade those to untyped `Unknown` AVPs.

So NASREQ must stay **loaded** (for decode) but **not advertised** (on the wire). That separation is exactly what filtering at the advertisement point provides; trimming the dictionary cannot express it.

## Tests

- New `diam/sm/cer_cea_pcrf_test.go`: wire-level CER→CEA exchange asserts the CEA advertises exactly the 4 apps, and that the identity is PCRF for Gx-only / Rx-only / Gx+Rx and the default for Gy / Sy / mixed CERs, plus the default when PcrfHost/PcrfRealm are unset.
- Updated the `TestStateMachine` golden CEA to the filtered output.

## Backwards compatibility

Additive `Settings` fields (empty = previous behaviour); the advertised-app set is unconditional. Consumed by the diameter-adapter via tag v4.0.35.

Refs https://github.com/trilogy-group/eng-maintenance/issues/21086