### PR TITLE
feat(dict): register Bearer-Control-Mode (AVP 1023) in built-in Gx application

### DIFF
--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -101,6 +101,7 @@ const (
 	BaseTimeInterval                           = 1265
 	BasicServiceCode                           = 3411
 	BearerCapability                           = 3412
+	BearerControlMode                          = 1023
 	BearerIdentifier                           = 1020
 	BearerService                              = 854
 	BearerUsage                                = 1000

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -1532,6 +1532,15 @@ var gxcreditcontrolXML = `<?xml version="1.0" encoding="UTF-8"?>
             </data>
         </avp>
 
+        <avp name="Bearer-Control-Mode" code="1023" must="M,V" may="P" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 Section 5.3.23 -->
+            <data type="Enumerated">
+                <item code="0" name="UE_only"/>
+                <item code="1" name="RESERVED"/>
+                <item code="2" name="UE_NW"/>
+            </data>
+        </avp>
+
         <avp name="TGPP-SGSN-Address" code="6" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
             <!-- 3GPP 29.061 Table 9a -->
             <data type="OctetString"/>

--- a/diam/dict/testdata/gx_credit_control.xml
+++ b/diam/dict/testdata/gx_credit_control.xml
@@ -380,6 +380,15 @@
             </data>
         </avp>
 
+        <avp name="Bearer-Control-Mode" code="1023" must="M,V" may="P" may-encrypt="y" vendor-id="10415">
+            <!-- 3GPP 29.212 Section 5.3.23 -->
+            <data type="Enumerated">
+                <item code="0" name="UE_only"/>
+                <item code="1" name="RESERVED"/>
+                <item code="2" name="UE_NW"/>
+            </data>
+        </avp>
+
         <avp name="TGPP-SGSN-Address" code="6" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
             <!-- 3GPP 29.061 Table 9a -->
             <data type="OctetString"/>


### PR DESCRIPTION
## Why

The built-in Gx application (16777238) dictionary did not define **Bearer-Control-Mode** (AVP 1023, Enumerated, vendor 10415, 3GPP TS 29.212 §5.3.23).

The ccab diameter-adapter (GPBC milestone #282, IF4) needs to emit this AVP in the Gx CCA. It worked around the missing definition by runtime-`Load()`-ing a second `<application id="16777238">` fragment. Because `dict.Load` appends files and `Apps()`/CEA do not dedupe same-ID applications, this added a **duplicate** Gx app entry → the CER/CEA advertised an extra `Supported-Vendor-Id` (10415) and a duplicate `Vendor-Specific-Application-Id` (16777238). (Surfaced by ccab `DiameterCerIT`.)

## What

Register AVP 1023 natively in the built-in Gx `<application>`, beside AVP 1022 (`Access-Network-Charging-Identifier-Gx`), mirroring the Enumerated items `UE_only(0)/RESERVED(1)/UE_NW(2)`.

This lets the adapter drop its runtime fragment, so the Gx app is advertised exactly once.

## Validation
- `go build ./...` clean; `go test ./diam/dict ./diam/sm` green.
- Probe: `FindAVP(16777238, "Bearer-Control-Mode")` → code 1023; `PrepareSupportedApps` yields a single 16777238 entry (no duplicate).

## Follow-up (consumer)
Tag a release; ccab bumps `go.mod` and removes `gx-dict-init.go`'s `bearerControlModeDictXML` + `init()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dictionary-only addition with no runtime logic changes; slightly expands the built-in Gx AVP set for encoding/lookup.
> 
> **Overview**
> Adds **Bearer-Control-Mode** (3GPP TS 29.212 §5.3.23, vendor 10415, code **1023**) to the built-in Gx application dictionary so it can be resolved and encoded without a second runtime dictionary fragment.
> 
> The change introduces `BearerControlMode = 1023` in `avp/codes.go` and mirrors the same Enumerated AVP definition (`UE_only` / `RESERVED` / `UE_NW`) in `diam/dict/default.go` and `diam/dict/testdata/gx_credit_control.xml`, placed next to AVP 1022.
> 
> Consumers that previously `Load()`’d an extra Gx app block only to define this AVP can drop that workaround and avoid duplicate Gx application entries in CER/CEA capability advertisement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3fd91347aac859013d4abc5c63d7a902dbb1923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->