### PR TITLE
sm: add OnCEA/OnDWA server-send handshake hooks (mirror of #233)

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -105,6 +105,10 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
 
+	if sm.cfg.OnCEA != nil {
+		sm.cfg.OnCEA(c, a)
+	}
+
 	return sm.cfg.AnswerHandlerProxy(func(conn diam.Conn, answer *diam.Message) error {
 		_, err = answer.WriteTo(conn)
 		if err != nil {
@@ -173,6 +177,10 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	}
 	if sm.cfg.FirmwareRevision != 0 {
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
+	}
+
+	if sm.cfg.OnCEA != nil {
+		sm.cfg.OnCEA(c, a)
 	}
 
 	return sm.cfg.AnswerHandlerProxy(func(conn diam.Conn, answer *diam.Message) error {

--- a/diam/sm/dwr.go
+++ b/diam/sm/dwr.go
@@ -40,6 +40,10 @@ func handleDWR(sm *StateMachine) diam.HandlerFunc {
 			m.NewAVP(avp.OriginStateID, avp.Mbit, 0, stateid)
 		}
 
+		if sm.cfg.OnDWA != nil {
+			sm.cfg.OnDWA(c, a)
+		}
+
 		sm.cfg.AnswerHandlerProxy(func(conn diam.Conn, answer *diam.Message) error {
 			_, err = answer.WriteTo(conn)
 			if err != nil {

--- a/diam/sm/hooks_test.go
+++ b/diam/sm/hooks_test.go
@@ -117,3 +117,180 @@ func TestOnDWRHook(t *testing.T) {
 		t.Fatal("OnDWR hook did not fire")
 	}
 }
+
+// TestOnCEAHook verifies that Settings.OnCEA fires on the server immediately
+// before a (success) CEA is sent, with the fully-constructed answer message,
+// and that the default handshake still completes. Mirror of TestOnCERHook
+// (PR #233) for the outbound CEA side.
+func TestOnCEAHook(t *testing.T) {
+	var onCEACalls int32
+	settings := *serverSettings
+	settings.OnCEA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.CapabilitiesExchange {
+			t.Errorf("OnCEA invoked for non-CEA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnCEA invoked with a request message, want an answer")
+		}
+		atomic.AddInt32(&onCEACalls, 1)
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete after OnCEA hook")
+	}
+
+	if got := atomic.LoadInt32(&onCEACalls); got != 1 {
+		t.Fatalf("OnCEA calls = %d, want 1", got)
+	}
+}
+
+// TestOnCEAHookErrorCEA verifies that Settings.OnCEA also fires when the
+// server answers a CER with an error CEA (here: no common application). The
+// fork's tracing relies on the hook firing on both the success and error
+// answer paths.
+func TestOnCEAHookErrorCEA(t *testing.T) {
+	var onCEACalls int32
+	onCEA := make(chan *diam.Message, 1)
+	settings := *serverSettings
+	settings.OnCEA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.CapabilitiesExchange {
+			t.Errorf("OnCEA invoked for non-CEA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnCEA invoked with a request message, want an answer")
+		}
+		if m.Header.CommandFlags&diam.ErrorFlag == 0 {
+			t.Errorf("OnCEA error-CEA message does not have the Error flag set")
+		}
+		atomic.AddInt32(&onCEACalls, 1)
+		select {
+		case onCEA <- m:
+		default:
+		}
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	// Request an application the server does not support, forcing errorCEA
+	// (DIAMETER_NO_COMMON_APPLICATION).
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(99999))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case a := <-onCEA:
+		if !testResultCode(a, diam.NoCommonApplication) {
+			t.Fatalf("OnCEA error answer Result-Code, want NoCommonApplication.\n%s", a)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnCEA hook did not fire on errorCEA")
+	}
+
+	if got := atomic.LoadInt32(&onCEACalls); got != 1 {
+		t.Fatalf("OnCEA calls = %d, want 1", got)
+	}
+}
+
+// TestOnDWAHook verifies that Settings.OnDWA fires on the server immediately
+// before a DWA is sent in response to a peer DWR, with the constructed answer.
+// Mirror of TestOnDWRHook (PR #233) for the outbound DWA side.
+func TestOnDWAHook(t *testing.T) {
+	onDWA := make(chan *diam.Message, 1)
+	settings := *serverSettings
+	settings.OnDWA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.DeviceWatchdog {
+			t.Errorf("OnDWA invoked for non-DWA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnDWA invoked with a request message, want an answer")
+		}
+		select {
+		case onDWA <- m:
+		default:
+		}
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	cer := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	cer.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	cer.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	cer.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	cer.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	cer.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	cer.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	cer.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	cer.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := cer.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete")
+	}
+
+	dwr := diam.NewRequest(diam.DeviceWatchdog, 0, dict.Default)
+	dwr.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	dwr.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	if _, err := dwr.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-onDWA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDWA hook did not fire")
+	}
+}

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -102,6 +102,23 @@ type Settings struct {
 	// peer has passed the handshake) before the state machine responds
 	// with DWA. Same semantics as OnCER.
 	OnDWR diam.HandlerFunc
+
+	// OnCEA, if non-nil, is invoked on the server immediately before a CEA
+	// is sent, after the message has been fully constructed. It fires for
+	// both the success CEA and the error CEA. Useful for logging or metrics.
+	// Mutating the message is permitted but discouraged. The hook runs in
+	// the goroutine handling the CER, so it must be cheap; spawn a goroutine
+	// for long-running work. The hook is observe-only on the connection: do
+	// not write to it. If the hook spawns a goroutine, that goroutine must
+	// not retain or touch the message after the hook returns — the state
+	// machine writes it to the wire immediately afterwards, so copy out any
+	// needed data synchronously first. Same semantics as OnCER.
+	OnCEA diam.HandlerFunc
+
+	// OnDWA, if non-nil, is invoked on the server immediately before a DWA
+	// is sent in response to a peer DWR, after the message has been fully
+	// constructed. Useful for logging or metrics. Same semantics as OnCEA.
+	OnDWA diam.HandlerFunc
 }
 
 var (


### PR DESCRIPTION
## What

Adds two server-side handshake pre-hooks to `sm.Settings`, the outbound-answer counterparts of `OnCER`/`OnDWR` (fiorix PR #233):

- **`OnCEA`** — fires on the server immediately before a CEA is sent, on the fully-constructed answer. Fires for **both** the success CEA (`cer.go::successCEA`) and the error CEA (`cer.go::errorCEA`).
- **`OnDWA`** — fires on the server immediately before a DWA is sent in response to a peer DWR (`dwr.go::handleDWR`).

Both are nil-guarded `diam.HandlerFunc` fields; default behaviour is unchanged when nil.

## Why

fiorix builds and sends CEA/DWA internally, and `sm.HandleFunc`/`HandleIdx` explicitly refuse registering CER/CEA/DWR handlers to protect the handshake. So the server's *outbound* handshake answers have no user interception point — exactly the situation PR #233 solved for inbound CER/DWR with `OnCER`/`OnDWR`. These two hooks complete the server-side quadrant (the client-receive pair `OnReceivedCEA`/`OnReceivedDWA` is a separate follow-up).

This is the ccab fork's first step in [DALR](https://github.com/trilogy-group/ccab/issues/16088) (T1.1.1) — replacing the fork's bespoke `AnswerHandlerProxy` tracing with idiomatic hooks, en route to upstreaming all four to fiorix.

## Shape / call sites

The hook is a manual call-site insert on the built answer `a`, immediately before the existing `AnswerHandlerProxy(...WriteTo)`:

```go
if sm.cfg.OnCEA != nil {
    sm.cfg.OnCEA(c, a)
}
```

Doc-comments mirror the `OnCER`/`OnDWR` style, plus an aliasing caveat: a hook that spawns a goroutine must not retain the message (the SM writes it next), and the hook is observe-only on the connection.

## Tests

`diam/sm/hooks_test.go` (alongside the existing `TestOnCERHook`/`TestOnDWRHook`):
- `TestOnCEAHook` — drives a CER, asserts `OnCEA` fires exactly once with a CEA answer (command code, answer-not-request).
- `TestOnCEAHookErrorCEA` — forces `NoCommonApplication`, asserts the hook fires once on the error CEA with the Error flag + correct Result-Code.
- `TestOnDWAHook` — drives a DWR after handshake, asserts `OnDWA` fires with the DWA answer.

`go test -race ./diam/sm/` green; `go vet` clean; `gofmt` clean. (`TestServerClose/sctp` fails on darwin/arm64 only — SCTP unsupported there; CI runs on Linux.)

## Base

Based on `upgrade/fiorix-v4.3.0` (the T0 fiorix-v4.3.0 fork upgrade, tag `v4.3.0-ccab.3`) — stacks on PR #23. Tag `v4.3.0-ccab.4` to be cut after review.

## Notes for reviewer

- Pure additive: no signature changes, no behaviour change for nil hooks (existing tests pass unmodified).
- The matching ccab consumer (server tracing swap) is ready in ccab #16094 (T1.1.2).
- Client-receive hooks + an upstream fiorix PR are tracked separately (ccab #16110, #16091).