### PR TITLE
sm: remove fork-only CEA/Metadata peer-capability extensions (DALR T4.2)

### DIFF
--- a/diam/sm/smparser/cea.go
+++ b/diam/sm/smparser/cea.go
@@ -18,9 +18,6 @@ type CEA struct {
 	OriginHost                  datatype.DiameterIdentity `avp:"Origin-Host"`
 	OriginRealm                 datatype.DiameterIdentity `avp:"Origin-Realm"`
 	OriginStateID               uint32                    `avp:"Origin-State-Id"`
-	VendorID                    uint32                    `avp:"Vendor-Id"`
-	ProductName                 string                    `avp:"Product-Name"`
-	SupportedVendorID           []*diam.AVP               `avp:"Supported-Vendor-Id"`
 	AcctApplicationID           []*diam.AVP               `avp:"Acct-Application-Id"`
 	AuthApplicationID           []*diam.AVP               `avp:"Auth-Application-Id"`
 	VendorSpecificApplicationID []*diam.AVP               `avp:"Vendor-Specific-Application-Id"`

--- a/diam/sm/smpeer/metadata.go
+++ b/diam/sm/smpeer/metadata.go
@@ -21,8 +21,6 @@ type Metadata struct {
 	OriginHost   datatype.DiameterIdentity
 	OriginRealm  datatype.DiameterIdentity
 	Applications []uint32 // Acct or Auth IDs supported by the peer.
-	Cer          *smparser.CER
-	Cea          *smparser.CEA
 }
 
 // FromCER creates a Metadata object from data in the CER.
@@ -31,7 +29,6 @@ func FromCER(cer *smparser.CER) *Metadata {
 		OriginHost:   cer.OriginHost,
 		OriginRealm:  cer.OriginRealm,
 		Applications: cer.Applications(),
-		Cer:          cer,
 	}
 }
 
@@ -41,7 +38,6 @@ func FromCEA(cea *smparser.CEA) *Metadata {
 		OriginHost:   cea.OriginHost,
 		OriginRealm:  cea.OriginRealm,
 		Applications: cea.Applications(),
-		Cea:          cea,
 	}
 }
 


### PR DESCRIPTION
## Summary

Rolls back the fork-only peer-capability extensions that existed solely to serve the diameter-adapter client's `/capabilities` IT endpoint:

- `smparser.CEA.{VendorID, ProductName, SupportedVendorID}` — removed
- `smpeer.Metadata.{Cer, Cea}` pointers — removed (and `FromCER`/`FromCEA` no longer set them)

After this change, `smparser.CEA` and `smpeer.Metadata` are **byte-identical to upstream fiorix v4.3.0** again. The fork retains only the `OnCER`/`OnDWR`/`OnCEA`/`OnDWA` handshake hooks (from the parent branch / PR #24).

## Why

The ccab `/capabilities` handler was the only consumer of these fields. It has been rewired (ccab DALR **T4.1**, ccab PR linked below) to read the advertised application list from vanilla `smpeer.Metadata.Applications`, which fiorix stores for free during the CER/CEA handshake. The sole IT (`DiameterCerIT`) now asserts that application list — the on-wire `{Gy,Gx,Rx,Sy}` advertisement guard — so the extra CEA fields are dead.

## Base / tagging

- Based on `T1.1.1-server-hooks` (PR #24, `v4.3.0-ccab.4`) so this commit retains the server-send hooks.
- Tag **`v4.3.0-ccab.5`** has been cut on the rollback commit; ccab is re-pinned to it.

## Validation

- `gofmt` clean; `go vet ./diam/sm/...` clean.
- `go test -race -cover ./diam/...`: `smparser` and `smpeer` pass (89.7% / 100.0%). The only failure locally is `TestServerClose/sctp` — SCTP is unsupported on darwin/arm64 (passes on Linux CI), unrelated to this change.

> ⚠️ **FF-only / `do-not-merge`** — merge manually via fast-forward to keep the fork's linear hooks history; do not squash/merge-commit via UI.

DALR T4.2 (ccab/trilogy-group#16097).