### PR TITLE
dict: stop loading fork-only Diameter Sy app (DALR T3-Sy)

### DIFF
--- a/diam/autogen.sh
+++ b/diam/autogen.sh
@@ -143,7 +143,6 @@ func init() {
 		{"TGPP_S6a", tgpps6aXML},
 		{"TGPP_S13", tgpps13XML},
 		{"TGPP_Swx", tgppswxXML},
-		{"Sy Interface", diametersyXML},
 	}
 	var err error
 	Default, err = NewParser()

--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -508,8 +508,6 @@ const (
 	PDPContext                                 = 1469
 	PDPContextType                             = 1247
 	PDPType                                    = 1470
-	PendingPolicyCounterChangeTime             = 2901
-	PendingPolicyCounterInformation            = 2905
 	PLMNClient                                 = 1482
 	PoCChangeCondition                         = 1261
 	PoCChangeTime                              = 1262
@@ -524,9 +522,6 @@ const (
 	PoCUserRole                                = 1252
 	PoCUserRoleIDs                             = 1253
 	PoCUserRoleinfoUnits                       = 1254
-	PolicyCounterIdentifier                    = 2901
-	PolicyCounterStatus                        = 2902
-	PolicyCounterStatusReport                  = 2903
 	PortLimit                                  = 62
 	PositioningData                            = 1245
 	Precedence                                 = 1010

--- a/diam/commands.go
+++ b/diam/commands.go
@@ -8,29 +8,28 @@ package diam
 
 // Diameter command codes.
 const (
-	AA                         = 265
-	AbortSession               = 274
-	Accounting                 = 271
-	AuthenticationInformation  = 318
-	CancelLocation             = 317
-	CapabilitiesExchange       = 257
-	CreditControl              = 272
-	DeleteSubscriberData       = 320
-	DeviceWatchdog             = 280
-	DisconnectPeer             = 282
-	InsertSubscriberData       = 319
-	MEIdentityCheck            = 324
-	MultimediaAuth             = 303
-	Notify                     = 323
-	PurgeUE                    = 321
-	ReAuth                     = 258
-	RegistrationTermination    = 304
-	Reset                      = 322
-	ServerAssignment           = 301
-	SessionTermination         = 275
-	SpendingLimit              = 8388635
-	SpendingStatusNotification = 8388636
-	UpdateLocation             = 316
+	AA                        = 265
+	AbortSession              = 274
+	Accounting                = 271
+	AuthenticationInformation = 318
+	CancelLocation            = 317
+	CapabilitiesExchange      = 257
+	CreditControl             = 272
+	DeleteSubscriberData      = 320
+	DeviceWatchdog            = 280
+	DisconnectPeer            = 282
+	InsertSubscriberData      = 319
+	MEIdentityCheck           = 324
+	MultimediaAuth            = 303
+	Notify                    = 323
+	PurgeUE                   = 321
+	ReAuth                    = 258
+	RegistrationTermination   = 304
+	Reset                     = 322
+	ServerAssignment          = 301
+	SessionTermination        = 275
+	SpendingLimit             = 8388635
+	UpdateLocation            = 316
 )
 
 // Short Command Names
@@ -75,8 +74,6 @@ const (
 	SAR = "SAR"
 	SLA = "SLA"
 	SLR = "SLR"
-	SNA = "SNA"
-	SNR = "SNR"
 	STA = "STA"
 	STR = "STR"
 	ULA = "ULA"

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -26,7 +26,6 @@ func init() {
 		{"TGPP_S6a", tgpps6aXML},
 		{"TGPP_S13", tgpps13XML},
 		{"TGPP_Swx", tgppswxXML},
-		{"Sy Interface", diametersyXML},
 	}
 	var err error
 	Default, err = NewParser()
@@ -1035,7 +1034,6 @@ var diametersyXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<!-- Diameter Credit Control Application -->
 		<!-- http://tools.ietf.org/html/rfc4006 -->
 
-        <vendor id="10415" name="TGPP"/>
 		<command code="8388635" short="SL" name="Spending-Limit">
 			<request>
 				<!-- http://tools.ietf.org/html/rfc4006#section-3.1 -->
@@ -1052,7 +1050,6 @@ var diametersyXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="Proxy-Info" required="false" max="1"/>
 				<rule avp="Route-Record" required="false" max="1"/>
 				<rule avp="Service-Information" required="false" max="1"/>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
 			</request>
 			<answer>
 				<!-- http://tools.ietf.org/html/rfc4006#section-3.2 -->
@@ -1067,75 +1064,16 @@ var diametersyXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="Proxy-Info" required="false" max="1"/>
 				<rule avp="Route-Record" required="false" max="1"/>
 				<rule avp="Failed-AVP" required="false" max="1"/>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
 			</answer>
 		</command>
 
-		<command code="8388636" short="SN" name="Spending-Status-Notification">
-			<request>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
-			</request>
-			<answer>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
-			</answer>
-		</command>
-
-		<avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
-			<data type="OctetString">
-			</data>
-		</avp>
-		
-		<avp name="Policy-Counter-Status-Report" code="2903" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Grouped">
-				<rule avp="Policy-Counter-Identifier" required="true" max="1"/>
-				<rule avp="Policy-Counter-Status" required="true" max="1"/>
-				<rule avp="Pending-Policy-Counter-Information" required="false"/>
-			</data>
-		</avp>
-		<avp name="Pending-Policy-Counter-Information" code="2905" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Grouped">
-				<rule avp="Policy-Counter-Status" required="true" max="1"/>
-				<rule avp="Pending-Policy-Counter-Change-Time" required="true" max="1"/>
-			</data>
-		</avp>
-
-		<avp name="Pending-Policy-Counter-Change-Time" code="2901" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Time"/>
-		</avp>
-		<avp name="Policy-Counter-Identifier" code="2901" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-		<avp name="Policy-Counter-Status" code="2902" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-
-		<avp name="SL-Request-Type" code="2904" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
+		<avp name="SL-Request-Type" code="2904" must="M" may="P" must-not="V" may-encrypt="-">
 			<data type="Enumerated">
 				<item code="0" name="INITIAL_REQUEST"/>
 				<item code="1" name="INTERMEDIATE_REQUEST"/>
 			</data>
 		</avp>
 		
-		<avp name="Subscription-Id" code="443" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.46-->
-			<data type="Grouped">
-				<rule avp="Subscription-Id-Type" required="true" max="1"/>
-				<rule avp="Subscription-Id-Data" required="true" max="1"/>
-			</data>
-		</avp>
-		<avp name="Subscription-Id-Data" code="444" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.48-->
-			<data type="UTF8String"/>
-		</avp>
-		<avp name="Subscription-Id-Type" code="450" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.47-->
-			<data type="Enumerated">
-				<item code="0" name="END_USER_E164"/>
-				<item code="1" name="END_USER_IMSI"/>
-				<item code="2" name="END_USER_SIP_URI"/>
-				<item code="3" name="END_USER_NAI"/>
-			</data>
-		</avp>
     </application>
 </diameter>`
 

--- a/diam/dict/testdata/diameter_sy.xml
+++ b/diam/dict/testdata/diameter_sy.xml
@@ -5,7 +5,6 @@
 		<!-- Diameter Credit Control Application -->
 		<!-- http://tools.ietf.org/html/rfc4006 -->
 
-        <vendor id="10415" name="TGPP"/>
 		<command code="8388635" short="SL" name="Spending-Limit">
 			<request>
 				<!-- http://tools.ietf.org/html/rfc4006#section-3.1 -->
@@ -22,7 +21,6 @@
 				<rule avp="Proxy-Info" required="false" max="1"/>
 				<rule avp="Route-Record" required="false" max="1"/>
 				<rule avp="Service-Information" required="false" max="1"/>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
 			</request>
 			<answer>
 				<!-- http://tools.ietf.org/html/rfc4006#section-3.2 -->
@@ -37,75 +35,15 @@
 				<rule avp="Proxy-Info" required="false" max="1"/>
 				<rule avp="Route-Record" required="false" max="1"/>
 				<rule avp="Failed-AVP" required="false" max="1"/>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
 			</answer>
 		</command>
 
-		<command code="8388636" short="SN" name="Spending-Status-Notification">
-			<request>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
-			</request>
-			<answer>
-				<rule avp="Policy-Counter-Status-Report" required="false" max="1"/>
-			</answer>
-		</command>
-
-		<avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
-			<data type="OctetString">
-			</data>
-		</avp>
-		
-		<avp name="Policy-Counter-Status-Report" code="2903" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Grouped">
-				<rule avp="Policy-Counter-Identifier" required="true" max="1"/>
-				<rule avp="Policy-Counter-Status" required="true" max="1"/>
-				<rule avp="Pending-Policy-Counter-Information" required="false"/>
-			</data>
-		</avp>
-		<avp name="Pending-Policy-Counter-Information" code="2905" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Grouped">
-				<rule avp="Policy-Counter-Status" required="true" max="1"/>
-				<rule avp="Pending-Policy-Counter-Change-Time" required="true" max="1"/>
-			</data>
-		</avp>
-
-		<avp name="Pending-Policy-Counter-Change-Time" code="2901" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="Time"/>
-		</avp>
-		<avp name="Policy-Counter-Identifier" code="2901" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-		<avp name="Policy-Counter-Status" code="2902" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-
-		<avp name="SL-Request-Type" code="2904" must="M" may="P" must-not="V" may-encrypt="-" vendor-id="10415">
+		<avp name="SL-Request-Type" code="2904" must="M" may="P" must-not="V" may-encrypt="-">
 			<data type="Enumerated">
 				<item code="0" name="INITIAL_REQUEST"/>
 				<item code="1" name="INTERMEDIATE_REQUEST"/>
 			</data>
 		</avp>
 		
-		<avp name="Subscription-Id" code="443" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.46-->
-			<data type="Grouped">
-				<rule avp="Subscription-Id-Type" required="true" max="1"/>
-				<rule avp="Subscription-Id-Data" required="true" max="1"/>
-			</data>
-		</avp>
-		<avp name="Subscription-Id-Data" code="444" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.48-->
-			<data type="UTF8String"/>
-		</avp>
-		<avp name="Subscription-Id-Type" code="450" must="M" may="P" must-not="V" may-encrypt="Y">
-			<!-- http://tools.ietf.org/html/rfc4006#section-8.47-->
-			<data type="Enumerated">
-				<item code="0" name="END_USER_E164"/>
-				<item code="1" name="END_USER_IMSI"/>
-				<item code="2" name="END_USER_SIP_URI"/>
-				<item code="3" name="END_USER_NAI"/>
-			</data>
-		</avp>
     </application>
 </diameter>
-

--- a/diam/dict/util_test.go
+++ b/diam/dict/util_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestApps(t *testing.T) {
 	apps := Default.Apps()
-	if len(apps) != 11 {
-		t.Fatalf("Unexpected # of apps. Want 11, have %d", len(apps))
+	if len(apps) != 10 {
+		t.Fatalf("Unexpected # of apps. Want 10, have %d", len(apps))
 	}
 	// Base protocol.
 	if apps[0].ID != 0 {
@@ -49,10 +49,6 @@ func TestApps(t *testing.T) {
 	// 3GPP Swx applications
 	if apps[9].ID != 16777265 {
 		t.Fatalf("Unexpected app.ID. Want 16777265, have %d", apps[9].ID)
-	}
-	// Diameter Sy
-	if apps[10].ID != 16777302 {
-		t.Fatalf("Unexpected app.ID. Want 16777302, have %d", apps[10].ID)
 	}
 }
 

--- a/diam/sm/cer_cea_pcrf_test.go
+++ b/diam/sm/cer_cea_pcrf_test.go
@@ -112,9 +112,8 @@ func exchangeCER(t *testing.T, settings *Settings, appIDs ...uint32) *diam.Messa
 }
 
 // TestCEA_AdvertisesOnlySupportedApps verifies that the CEA advertises only the
-// four applications this adapter supports (Gy, Rx, Gx, Sy), even though the
-// loaded dictionary contains more applications (NASREQ, Base Accounting, S6a,
-// SWx).
+// applications this adapter supports (Gy, Rx, Gx), even though the loaded
+// dictionary contains more applications (NASREQ, Base Accounting, S6a, SWx).
 func TestCEA_AdvertisesOnlySupportedApps(t *testing.T) {
 	cea := exchangeCER(t, pcrfServerSettings, diam.GX_CHARGING_CONTROL_APP_ID)
 	if !testResultCode(cea, diam.Success) {
@@ -126,7 +125,6 @@ func TestCEA_AdvertisesOnlySupportedApps(t *testing.T) {
 		diam.CHARGING_CONTROL_APP_ID:    true,
 		diam.RX_APP_ID:                  true,
 		diam.GX_CHARGING_CONTROL_APP_ID: true,
-		diam.DIAMETER_SY_APP_ID:         true,
 	}
 	for id := range want {
 		if !got[id] {
@@ -156,7 +154,6 @@ func TestCEA_PcrfIdentitySelection(t *testing.T) {
 		{"rx only", []uint32{diam.RX_APP_ID}, "pcrf.example.com", "pcrf-realm.example.com"},
 		{"gx and rx", []uint32{diam.GX_CHARGING_CONTROL_APP_ID, diam.RX_APP_ID}, "pcrf.example.com", "pcrf-realm.example.com"},
 		{"gy only", []uint32{diam.CHARGING_CONTROL_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
-		{"sy only", []uint32{diam.DIAMETER_SY_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
 		{"gx and gy", []uint32{diam.GX_CHARGING_CONTROL_APP_ID, diam.CHARGING_CONTROL_APP_ID}, "ocs.example.com", "ocs-realm.example.com"},
 	}
 

--- a/diam/sm/sm_test.go
+++ b/diam/sm/sm_test.go
@@ -103,7 +103,7 @@ func testStateMachine(t *testing.T, network string, settings *Settings) {
 
 		expectedCea := strings.TrimSpace(fmt.Sprintf(`
 Capabilities-Exchange-Answer (CEA)
-{Code:257,Flags:0x0,Version:0x1,Length:316,ApplicationId:1001,HopByHopId:0x%x,EndToEndId:0x%x}
+{Code:257,Flags:0x0,Version:0x1,Length:272,ApplicationId:1001,HopByHopId:0x%x,EndToEndId:0x%x}
 	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
 	Origin-Host {Code:264,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{srv},Padding:1}
 	Origin-Realm {Code:296,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{test},Padding:0}
@@ -126,11 +126,6 @@ Capabilities-Exchange-Answer (CEA)
 	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
 		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777236}},
-	}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777302}},
 	}}
 	Firmware-Revision {Code:267,Flags:0x0,Length:12,VendorId:0,Value:Unsigned32{1}}
 


### PR DESCRIPTION
> # ⚠️ DO NOT MERGE VIA THE GITHUB UI ⚠️
>
> **FAST-FORWARD merge to `master` only** — the release tag **`v4.3.0-ccab.8`** is on this PR's head commit. A squash/rebase/merge-commit from the UI creates a NEW commit, orphaning the tag and poisoning the Go module proxy / ccab `replace` pin.
>
> ```
> git checkout master && git merge --ff-only T3-Sy-remove-dict && git push origin master
> ```
> Remove the `do-not-merge` label only at the moment of the manual FF-merge.

---

## DALR T3-Sy — fully de-fork the Diameter Sy application (ccab #16123)

Part of the Diameter Adapter Library Refactor (milestone ccab #286). Removes the trilogy fork's **entire** Diameter Sy (16777302) divergence from upstream fiorix v4.3.0 — both the dict **load** and the extended **source** — so the fork's Sy footprint equals vanilla. ccab now owns the full Sy dictionary via `diameter-adapter/common/dict`.

### What changed (8 files)
- **`diam/dict/testdata/diameter_sy.xml`** — restored to the vanilla fiorix stub (byte-identical): only the SL command + SL-Request-Type AVP remain. The fork-extended Sy (SN command 8388636, Policy-Counter AVPs 2901-2905, Subscription-Id 443/444/450, Provider-Id) is removed.
- **`diam/autogen.sh` + `diam/dict/default.go`** — drop the `{"Sy Interface", diametersyXML}` load entry; regenerated `default.go` Sy literal now matches vanilla.
- **`diam/commands.go` / `diam/avp/codes.go`** — regenerated: Sy-derived constants gone (`SpendingStatusNotification`, `SNA`/`SNR`, `PolicyCounter*`). `SpendingLimit` / `SL-Request-Type` / `DIAMETER_SY_APP_ID` stay (vanilla has them). The `MultimediaAuthentication` deprecated alias is preserved (vanilla appends it post-autogen).
- Fork-only test fixtures updated (util_test 11→10 apps; sm_test CEA length; cer_cea_pcrf).

### Result
`diff` of the fork's Sy source / `commands.go` / Sy `avp/codes` against vanilla fiorix v4.3.0 is now **empty** — Sy is genuinely de-forked, not merely unloaded.

### Verification
- `go test -race -cover ./diam/...` green (only `TestServerClose/sctp` fails — pre-existing darwin/arm64 SCTP env skip; green on Linux CI).
- ccab side (PR #16132): full goCoverageTester suite green; **DiameterCerIT** + **SpendingLimitControlWithIdTypeIT** pass end-to-end on a DA built from this de-forked fork (Sy advertised + SLR/Subscription-Id resolved via common/dict).
- Sy notifications safe: the sender (`lambdas/go/diameter-notifier-handler`) is on vanilla fiorix and builds AVPs by raw code (no dict dependency).

### Release
Tag **`v4.3.0-ccab.8`** on the head commit; ccab `replace` re-pinned .7→.8 (.7 abandoned). 

DALR T3-Sy · ccab #16123
