### PR TITLE
dict: de-fork Gx + Ro/Rf custom AVP definitions (DALR T3-Gx-RoRf)

### DIFF
--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -14,7 +14,6 @@ const (
 	AccessNetworkChargingIdentifier            = 502
 	AccessNetworkChargingIdentifierGx          = 1022
 	AccessNetworkChargingIdentifierValue       = 503
-	AccessNetworkInfoChange                    = 4401
 	AccessNetworkInformation                   = 1263
 	AccessRestrictionData                      = 1426
 	AccessTransferInformation                  = 2709
@@ -60,8 +59,6 @@ const (
 	AMBR                                       = 1435
 	ANGWAddress                                = 1050
 	ANID                                       = 1504
-	AnnouncementIdentifier                     = 3905
-	AnnouncementInformation                    = 3904
 	ANTrusted                                  = 1503
 	AoCCostInformation                         = 2053
 	AoCFormat                                  = 2310
@@ -104,7 +101,6 @@ const (
 	BaseTimeInterval                           = 1265
 	BasicServiceCode                           = 3411
 	BearerCapability                           = 3412
-	BearerControlMode                          = 1023
 	BearerIdentifier                           = 1020
 	BearerService                              = 854
 	BearerUsage                                = 1000
@@ -113,8 +109,6 @@ const (
 	CallbackNumber                             = 19
 	CallBarringInfo                            = 1488
 	CalledAssertedIdentity                     = 1250
-	CalledIdentity                             = 3916
-	CalledIdentityChange                       = 3917
 	CalledPartyAddress                         = 832
 	CalledStationID                            = 30
 	CalleeInformation                          = 565
@@ -135,7 +129,6 @@ const (
 	CCTime                                     = 420
 	CCTotalOctets                              = 421
 	CCUnitType                                 = 454
-	CellularNetworkInformation                 = 3924
 	CGAddress                                  = 846
 	ChangeCondition                            = 2037
 	ChangeTime                                 = 2038
@@ -152,7 +145,6 @@ const (
 	ChargingRuleInstall                        = 1001
 	ChargingRuleName                           = 1005
 	ChargingRuleRemove                         = 1002
-	ChargingRuleReport                         = 1018
 	CheckBalanceResult                         = 422
 	Class                                      = 25
 	ClassIdentifier                            = 1214
@@ -179,7 +171,6 @@ const (
 	CostUnit                                   = 424
 	CreditControl                              = 426
 	CreditControlFailureHandling               = 427
-	CreditManagementStatus                     = 1082
 	CSGAccessMode                              = 2317
 	CSGID                                      = 1437
 	CSGMembershipIndication                    = 2318
@@ -248,7 +239,6 @@ const (
 	FailedAVP                                  = 279
 	FeatureList                                = 630
 	FeatureListID                              = 629
-	FEIdentifierList                           = 4413
 	FileRepairSupported                        = 1224
 	FilterID                                   = 11
 	FinalUnitAction                            = 449
@@ -327,8 +317,6 @@ const (
 	InterfaceText                              = 2005
 	InterfaceType                              = 2006
 	InterOperatorIdentifier                    = 838
-	InterUETransfer                            = 3902
-	IPCANSessionChargingScope                  = 2827
 	IPCANType                                  = 1027
 	IPDomainID                                 = 537
 	IPRealmDefaultIndication                   = 2603
@@ -490,16 +478,13 @@ const (
 	OriginStateID                              = 278
 	OutgoingSessionID                          = 2320
 	OutgoingTrunkGroupID                       = 853
-	PacketFilterContent                        = 1059
 	PacketFilterIdentifier                     = 1060
-	PacketFilterInformation                    = 1061
 	PacketFilterUsage                          = 1072
 	ParticipantAccessPriority                  = 1259
 	ParticipantActionType                      = 2049
 	ParticipantGroup                           = 1260
 	ParticipantsInvolved                       = 887
 	PasswordRetry                              = 75
-	PCCRuleStatus                              = 1019
 	PDNConnectionChargingID                    = 2050
 	PDNGWAllocationType                        = 1438
 	PDNType                                    = 1456
@@ -616,7 +601,6 @@ const (
 	RSBandwidth                                = 522
 	RuleActivationTime                         = 1043
 	RuleDeactivationTime                       = 1044
-	RuleFailureCode                            = 1031
 	RxRequestType                              = 533
 	ScaleFactor                                = 2059
 	SDPAnswerTimestamp                         = 1275
@@ -746,13 +730,11 @@ const (
 	TGPPMSTimeZone                             = 23
 	TGPPNSAPI                                  = 10
 	TGPPPDPType                                = 3
-	TGPPPSDataOffStatus                        = 2847
 	TGPPRATType                                = 21
 	TGPPSelectionMode                          = 12
 	TGPPServiceType                            = 1483
 	TGPPSessionStopIndicator                   = 11
 	TGPPSGSNAddress                            = 6
-	TGPPSGSNIPv6Address                        = 15
 	TGPPSGSNMCCMNC                             = 18
 	TGPPUserLocationInfo                       = 22
 	TimeFirstUsage                             = 2043

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -1459,15 +1459,6 @@ var gxcreditcontrolXML = `<?xml version="1.0" encoding="UTF-8"?>
             </data>
         </avp>
 
-        <avp name="Bearer-Control-Mode" code="1023" must="M,V" may="P" may-encrypt="y" vendor-id="10415">
-            <!-- 3GPP 29.212 Section 5.3.23 -->
-            <data type="Enumerated">
-                <item code="0" name="UE_only"/>
-                <item code="1" name="RESERVED"/>
-                <item code="2" name="UE_NW"/>
-            </data>
-        </avp>
-
         <avp name="TGPP-SGSN-Address" code="6" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
             <!-- 3GPP 29.061 Table 9a -->
             <data type="OctetString"/>
@@ -1505,115 +1496,6 @@ var gxcreditcontrolXML = `<?xml version="1.0" encoding="UTF-8"?>
                 <!-- *[ AVP ]-->
             </data>
         </avp>
-
-        <avp name="TGPP-SGSN-IPv6-Address" code="15" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.061 -->
-			<data type="OctetString"/>
-		</avp>
-
-		<avp name="TGPP-PS-Data-Off-Status" code="2847" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.133 -->
-			<data type="Enumerated">
-				<item code="0" name="ACTIVE"/>
-				<item code="1" name="INACTIVE"/>
-			</data>
-		</avp>
-
-		<avp name="Credit-Management-Status" code="1082" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.102 -->
-			<data type="Unsigned32"/>
-		</avp>
-
-		<avp name="Packet-Filter-Information" code="1061" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.56 -->
-			<data type="Grouped"/>
-			<grouped>
-                <rule avp="Packet-Filter-Identifier" required="false" max="1"/>
-                <rule avp="Precedence" required="false" max="1"/>
-                <rule avp="Packet-Filter-Content" required="false" max="1"/>
-                <rule avp="ToS-Traffic-Class" required="false" max="1"/>
-                <rule avp="Security-Parameter-Index" required="false" max="1"/>
-                <rule avp="Flow-Label" required="false" max="1"/>
-                <rule avp="Flow-Direction" required="false" max="1"/>
-                <!-- *[ AVP ]-->
-			</grouped>
-		</avp>
-
-		<avp name="Packet-Filter-Content" code="1059" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.54 -->
-			<data type="IPFilterRule"/>
-		</avp>
-
-		<avp name="Charging-Rule-Report" code="1018" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.18 -->
-			<data type="Grouped"/>
-			<grouped>
-                <rule avp="Charging-Rule-Name" required="false"/>
-                <rule avp="Charging-Rule-Base-Name" required="false"/>
-                <rule avp="Bearer-Identifier" required="false" max="1"/>
-                <rule avp="PCC-Rule-Status" required="false" max="1"/>
-                <rule avp="Rule-Failure-Code" required="false" max="1"/>
-                <rule avp="Final-Unit-Indication" required="false" max="1"/>
-                <rule avp="RAN-NAS-Release-Cause" required="false"/>
-                <rule avp="Content-Version" required="false"/>
-			</grouped>
-		</avp>
-
-		<avp name="PCC-Rule-Status" code="1019" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.19 -->
-			<data type="Enumerated">
-				<item code="0" name="ACTIVE"/>
-				<item code="1" name="INACTIVE"/>
-				<item code="2" name="TEMPORARILY_INACTIVE"/>
-			</data>
-		</avp>
-
-		<avp name="Rule-Failure-Code" code="1031" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.38 -->
-			<data type="Enumerated">
-				<item code="1" name="UNKNOWN_RULE_NAME"/>
-				<item code="2" name="RATING_GROUP_ERROR"/>
-				<item code="3" name="SERVICE_IDENTIFIER_ERROR"/>
-				<item code="4" name="GW/PCEF_MALFUNCTION"/>
-				<item code="5" name="RESOURCES_LIMITATION"/>
-				<item code="6" name="MAX_NR_BEARERS_REACHED"/>
-				<item code="7" name="UNKNOWN_BEARER_ID"/>
-				<item code="8" name="MISSING_BEARER_ID"/>
-				<item code="9" name="MISSING_FLOW_INFORMATION"/>
-				<item code="10" name="RESOURCE_ALLOCATION_FAILURE"/>
-				<item code="11" name="UNSUCCESSFUL_QOS_VALIDATION"/>
-				<item code="12" name="INCORRECT_FLOW_INFORMATION"/>
-				<item code="13" name="PS_TO_CS_HANDOVER"/>
-				<item code="14" name="TDF_APPLICATION_IDENTIFIER_ERROR"/>
-				<item code="15" name="NO_BEARER_BOUND"/>
-				<item code="16" name="FILTER_RESTRICTIONS"/>
-				<item code="17" name="AN_GW_FAILED"/>
-				<item code="18" name="MISSING_REDIRECT_SERVER_ADDRESS"/>
-				<item code="19" name="CM_END_USER_SERVICE_DENIED"/>
-				<item code="20" name="CM_CREDIT_CONTROL_NOT_APPLICABLE"/>
-				<item code="21" name="CM_AUTHORIZATION_REJECTED"/>
-				<item code="22" name="CM_USER_UNKNOWN"/>
-				<item code="23" name="CM_RATING_FAILED"/>
-				<item code="24" name="ROUTING_RULE_REJECTION"/>
-				<item code="25" name="UNKNOWN_ROUTING_ACCESS_INFORMATION"/>
-				<item code="26" name="NO_NBIFOM_SUPPORT"/>
-				<item code="27" name="UE_STATE_SUSPEND"/>
-				<item code="28" name="TRAFFIC_STEERING_ERROR"/>
-				<item code="29" name="SAME_TIME_ERROR"/>
-			</data>
-		</avp>
-
-		<avp name="IP-CAN-Session-Charging-Scope" code="2827" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.114 -->
-			<data type="Enumerated">
-				<item code="0" name="IP-CAN_SESSION_SCOPE"/>
-			</data>
-		</avp>
-
-        <avp name="Content-Version" code="552" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.214 5.3.49 -->
-			<data type="Unsigned64"/>
-		</avp>
 
     </application>
 </diameter>`
@@ -3270,7 +3152,7 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="SDP-Media-Component" required="false"/>
 				<rule avp="Served-Party-IP-Address" required="false" max="1"/>
 				<rule avp="Server-Capabilities" required="false" max="1"/>
-				<rule avp="Trunk-Group-ID" required="false" max="1"/>
+				<rule avp="Trunk-Group-Id" required="false" max="1"/>
 				<rule avp="Bearer-Service" required="false" max="1"/>
 				<rule avp="Service-Id" required="false" max="1"/>
 				<rule avp="Service-Specific-Info" required="false"/>
@@ -3296,8 +3178,6 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="Route-Header-Transmitted" required="false" max="1"/>
 				<rule avp="Instance-Id" required="false" max="1"/>
 				<rule avp="TAD-Identifier" required="false" max="1"/>
-				<rule avp="FE-Identifier-List" required="false" max="1"/>
-				<rule avp="Cellular-Network-Information" required="false" max="1"/>
 			</data>
 		</avp>
 
@@ -3312,7 +3192,7 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 			</data>
 		</avp>
 
-		<avp name="Incoming-Trunk-Group-ID" code="852" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Incoming-Trunk-Group-Id" code="852" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
 
@@ -3884,7 +3764,7 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 			<data type="UTF8String"/>
 		</avp>
 
-		<avp name="Outgoing-Trunk-Group-ID" code="853" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Outgoing-Trunk-Group-Id" code="853" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
 
@@ -4775,14 +4655,6 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 			</data>
 		</avp>
 
-		<avp name="FE-Identifier-List" code="4413" must="V,M"	may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-
-		<avp name="Cellular-Network-Information" code="3924" must="V,M" may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-			<data type="OctetString"/>
-		</avp>
-
 		<avp name="Talk-Burst-Exchange" code="1255" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="Grouped">
 				<rule avp="PoC-Change-Time" required="true" max="1"/>
@@ -4974,10 +4846,10 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 			</data>
 		</avp>
 
-		<avp name="Trunk-Group-ID" code="851" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Trunk-Group-Id" code="851" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="Grouped">
-				<rule avp="Incoming-Trunk-Group-ID" required="false" max="1"/>
-				<rule avp="Outgoing-Trunk-Group-ID" required="false" max="1"/>
+				<rule avp="Incoming-Trunk-Group-Id" required="false" max="1"/>
+				<rule avp="Outgoing-Trunk-Group-Id" required="false" max="1"/>
 			</data>
 		</avp>
 
@@ -5102,48 +4974,6 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 
     <avp name="Extended-APN-AMBR-UL" code="2849" must="V" must-not="M" may="P" may-encrypt="Y" vendor-id="10415">
       <data type="Unsigned32"/>
-    </avp>
-
-    <!--
-      ccab fork additions, backported from the previously hand-edited dict/default.go
-      into this source XML so that autogen.sh regenerates default.go losslessly.
-      See 3GPP TS 32.299 (Announcement-*, Called-Identity*, Inter-UE-Transfer,
-      Access-Network-Info-Change).
-    -->
-    <avp name="Announcement-Information" code="3904" must="M" may="P" must-not="V" may-encrypt="Y">
-      <data type="Grouped">
-        <rule avp="Announcement-Identifier" required="true" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Announcement-Identifier" code="3905" must="M" may="P" must-not="V" may-encrypt="Y">
-      <data type="Unsigned32"/>
-    </avp>
-
-    <avp name="Called-Identity" code="3916" must="V,M" may-encrypt="N" vendor-id="10415">
-      <data type="UTF8String"/>
-    </avp>
-
-    <avp name="Called-Identity-Change" code="3917" must="V,M" may-encrypt="N" vendor-id="10415">
-      <data type="Grouped">
-        <rule avp="Called-Identity" required="false" max="1"/>
-        <rule avp="Change-Time" required="false" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Access-Network-Info-Change" code="4401" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
-      <data type="Grouped">
-        <rule avp="Access-Network-Information" required="false" max="1"/>
-        <rule avp="Cellular-Network-Information" required="false" max="1"/>
-        <rule avp="Change-Time" required="false" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Inter-UE-Transfer" code="3902" must="V,M" may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-      <data type="Enumerated">
-        <item code="0" name="Intra-UE transfer"/>
-        <item code="1" name="Inter-UE transfer"/>
-      </data>
     </avp>
 
 	</application>

--- a/diam/dict/testdata/gx_credit_control.xml
+++ b/diam/dict/testdata/gx_credit_control.xml
@@ -380,15 +380,6 @@
             </data>
         </avp>
 
-        <avp name="Bearer-Control-Mode" code="1023" must="M,V" may="P" may-encrypt="y" vendor-id="10415">
-            <!-- 3GPP 29.212 Section 5.3.23 -->
-            <data type="Enumerated">
-                <item code="0" name="UE_only"/>
-                <item code="1" name="RESERVED"/>
-                <item code="2" name="UE_NW"/>
-            </data>
-        </avp>
-
         <avp name="TGPP-SGSN-Address" code="6" must="V" may="P" must-not="M" may-encrypt="y" vendor-id="10415">
             <!-- 3GPP 29.061 Table 9a -->
             <data type="OctetString"/>
@@ -426,115 +417,6 @@
                 <!-- *[ AVP ]-->
             </data>
         </avp>
-
-        <avp name="TGPP-SGSN-IPv6-Address" code="15" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.061 -->
-			<data type="OctetString"/>
-		</avp>
-
-		<avp name="TGPP-PS-Data-Off-Status" code="2847" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.133 -->
-			<data type="Enumerated">
-				<item code="0" name="ACTIVE"/>
-				<item code="1" name="INACTIVE"/>
-			</data>
-		</avp>
-
-		<avp name="Credit-Management-Status" code="1082" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.102 -->
-			<data type="Unsigned32"/>
-		</avp>
-
-		<avp name="Packet-Filter-Information" code="1061" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.56 -->
-			<data type="Grouped"/>
-			<grouped>
-                <rule avp="Packet-Filter-Identifier" required="false" max="1"/>
-                <rule avp="Precedence" required="false" max="1"/>
-                <rule avp="Packet-Filter-Content" required="false" max="1"/>
-                <rule avp="ToS-Traffic-Class" required="false" max="1"/>
-                <rule avp="Security-Parameter-Index" required="false" max="1"/>
-                <rule avp="Flow-Label" required="false" max="1"/>
-                <rule avp="Flow-Direction" required="false" max="1"/>
-                <!-- *[ AVP ]-->
-			</grouped>
-		</avp>
-
-		<avp name="Packet-Filter-Content" code="1059" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.54 -->
-			<data type="IPFilterRule"/>
-		</avp>
-
-		<avp name="Charging-Rule-Report" code="1018" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.18 -->
-			<data type="Grouped"/>
-			<grouped>
-                <rule avp="Charging-Rule-Name" required="false"/>
-                <rule avp="Charging-Rule-Base-Name" required="false"/>
-                <rule avp="Bearer-Identifier" required="false" max="1"/>
-                <rule avp="PCC-Rule-Status" required="false" max="1"/>
-                <rule avp="Rule-Failure-Code" required="false" max="1"/>
-                <rule avp="Final-Unit-Indication" required="false" max="1"/>
-                <rule avp="RAN-NAS-Release-Cause" required="false"/>
-                <rule avp="Content-Version" required="false"/>
-			</grouped>
-		</avp>
-
-		<avp name="PCC-Rule-Status" code="1019" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.19 -->
-			<data type="Enumerated">
-				<item code="0" name="ACTIVE"/>
-				<item code="1" name="INACTIVE"/>
-				<item code="2" name="TEMPORARILY_INACTIVE"/>
-			</data>
-		</avp>
-
-		<avp name="Rule-Failure-Code" code="1031" must="M,V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.38 -->
-			<data type="Enumerated">
-				<item code="1" name="UNKNOWN_RULE_NAME"/>
-				<item code="2" name="RATING_GROUP_ERROR"/>
-				<item code="3" name="SERVICE_IDENTIFIER_ERROR"/>
-				<item code="4" name="GW/PCEF_MALFUNCTION"/>
-				<item code="5" name="RESOURCES_LIMITATION"/>
-				<item code="6" name="MAX_NR_BEARERS_REACHED"/>
-				<item code="7" name="UNKNOWN_BEARER_ID"/>
-				<item code="8" name="MISSING_BEARER_ID"/>
-				<item code="9" name="MISSING_FLOW_INFORMATION"/>
-				<item code="10" name="RESOURCE_ALLOCATION_FAILURE"/>
-				<item code="11" name="UNSUCCESSFUL_QOS_VALIDATION"/>
-				<item code="12" name="INCORRECT_FLOW_INFORMATION"/>
-				<item code="13" name="PS_TO_CS_HANDOVER"/>
-				<item code="14" name="TDF_APPLICATION_IDENTIFIER_ERROR"/>
-				<item code="15" name="NO_BEARER_BOUND"/>
-				<item code="16" name="FILTER_RESTRICTIONS"/>
-				<item code="17" name="AN_GW_FAILED"/>
-				<item code="18" name="MISSING_REDIRECT_SERVER_ADDRESS"/>
-				<item code="19" name="CM_END_USER_SERVICE_DENIED"/>
-				<item code="20" name="CM_CREDIT_CONTROL_NOT_APPLICABLE"/>
-				<item code="21" name="CM_AUTHORIZATION_REJECTED"/>
-				<item code="22" name="CM_USER_UNKNOWN"/>
-				<item code="23" name="CM_RATING_FAILED"/>
-				<item code="24" name="ROUTING_RULE_REJECTION"/>
-				<item code="25" name="UNKNOWN_ROUTING_ACCESS_INFORMATION"/>
-				<item code="26" name="NO_NBIFOM_SUPPORT"/>
-				<item code="27" name="UE_STATE_SUSPEND"/>
-				<item code="28" name="TRAFFIC_STEERING_ERROR"/>
-				<item code="29" name="SAME_TIME_ERROR"/>
-			</data>
-		</avp>
-
-		<avp name="IP-CAN-Session-Charging-Scope" code="2827" must="V" may="P" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.212 5.3.114 -->
-			<data type="Enumerated">
-				<item code="0" name="IP-CAN_SESSION_SCOPE"/>
-			</data>
-		</avp>
-
-        <avp name="Content-Version" code="552" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
-			<!-- 3GPP TS 29.214 5.3.49 -->
-			<data type="Unsigned64"/>
-		</avp>
 
     </application>
 </diameter>

--- a/diam/dict/testdata/tgpp_ro_rf.xml
+++ b/diam/dict/testdata/tgpp_ro_rf.xml
@@ -686,7 +686,7 @@
 				<rule avp="SDP-Media-Component" required="false"/>
 				<rule avp="Served-Party-IP-Address" required="false" max="1"/>
 				<rule avp="Server-Capabilities" required="false" max="1"/>
-				<rule avp="Trunk-Group-ID" required="false" max="1"/>
+				<rule avp="Trunk-Group-Id" required="false" max="1"/>
 				<rule avp="Bearer-Service" required="false" max="1"/>
 				<rule avp="Service-Id" required="false" max="1"/>
 				<rule avp="Service-Specific-Info" required="false"/>
@@ -712,8 +712,6 @@
 				<rule avp="Route-Header-Transmitted" required="false" max="1"/>
 				<rule avp="Instance-Id" required="false" max="1"/>
 				<rule avp="TAD-Identifier" required="false" max="1"/>
-				<rule avp="FE-Identifier-List" required="false" max="1"/>
-				<rule avp="Cellular-Network-Information" required="false" max="1"/>
 			</data>
 		</avp>
 
@@ -728,7 +726,7 @@
 			</data>
 		</avp>
 
-		<avp name="Incoming-Trunk-Group-ID" code="852" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Incoming-Trunk-Group-Id" code="852" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
 
@@ -1300,7 +1298,7 @@
 			<data type="UTF8String"/>
 		</avp>
 
-		<avp name="Outgoing-Trunk-Group-ID" code="853" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Outgoing-Trunk-Group-Id" code="853" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
 
@@ -2191,14 +2189,6 @@
 			</data>
 		</avp>
 
-		<avp name="FE-Identifier-List" code="4413" must="V,M"	may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-			<data type="UTF8String"/>
-		</avp>
-
-		<avp name="Cellular-Network-Information" code="3924" must="V,M" may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-			<data type="OctetString"/>
-		</avp>
-
 		<avp name="Talk-Burst-Exchange" code="1255" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="Grouped">
 				<rule avp="PoC-Change-Time" required="true" max="1"/>
@@ -2390,10 +2380,10 @@
 			</data>
 		</avp>
 
-		<avp name="Trunk-Group-ID" code="851" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
+		<avp name="Trunk-Group-Id" code="851" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="Grouped">
-				<rule avp="Incoming-Trunk-Group-ID" required="false" max="1"/>
-				<rule avp="Outgoing-Trunk-Group-ID" required="false" max="1"/>
+				<rule avp="Incoming-Trunk-Group-Id" required="false" max="1"/>
+				<rule avp="Outgoing-Trunk-Group-Id" required="false" max="1"/>
 			</data>
 		</avp>
 
@@ -2518,48 +2508,6 @@
 
     <avp name="Extended-APN-AMBR-UL" code="2849" must="V" must-not="M" may="P" may-encrypt="Y" vendor-id="10415">
       <data type="Unsigned32"/>
-    </avp>
-
-    <!--
-      ccab fork additions, backported from the previously hand-edited dict/default.go
-      into this source XML so that autogen.sh regenerates default.go losslessly.
-      See 3GPP TS 32.299 (Announcement-*, Called-Identity*, Inter-UE-Transfer,
-      Access-Network-Info-Change).
-    -->
-    <avp name="Announcement-Information" code="3904" must="M" may="P" must-not="V" may-encrypt="Y">
-      <data type="Grouped">
-        <rule avp="Announcement-Identifier" required="true" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Announcement-Identifier" code="3905" must="M" may="P" must-not="V" may-encrypt="Y">
-      <data type="Unsigned32"/>
-    </avp>
-
-    <avp name="Called-Identity" code="3916" must="V,M" may-encrypt="N" vendor-id="10415">
-      <data type="UTF8String"/>
-    </avp>
-
-    <avp name="Called-Identity-Change" code="3917" must="V,M" may-encrypt="N" vendor-id="10415">
-      <data type="Grouped">
-        <rule avp="Called-Identity" required="false" max="1"/>
-        <rule avp="Change-Time" required="false" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Access-Network-Info-Change" code="4401" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
-      <data type="Grouped">
-        <rule avp="Access-Network-Information" required="false" max="1"/>
-        <rule avp="Cellular-Network-Information" required="false" max="1"/>
-        <rule avp="Change-Time" required="false" max="1"/>
-      </data>
-    </avp>
-
-    <avp name="Inter-UE-Transfer" code="3902" must="V,M" may="-" must-not="-" may-encrypt="N" vendor-id="10415">
-      <data type="Enumerated">
-        <item code="0" name="Intra-UE transfer"/>
-        <item code="1" name="Inter-UE transfer"/>
-      </data>
     </avp>
 
 	</application>


### PR DESCRIPTION
> ## ⚠️ DO NOT SQUASH / MERGE-COMMIT — FAST-FORWARD ONLY ⚠️
>
> This PR carries release tag **`v4.3.0-ccab.9`** on its head commit. The ccab
> `replace` directives pin that exact tag. A UI squash or merge-commit creates a
> **new** commit and orphans the tag → the Go module proxy/pin can no longer
> resolve it, poisoning every ccab build.
>
> **Merge procedure:** `git checkout master && git merge --ff-only T3-Gx-RoRf-remove-dict && git push`, then remove the `do-not-merge` label.

---

**DALR T3-Gx-RoRf** (ccab trilogy-group/ccab#16125) — dictionary slice 3 of 4.

> **Stacked on #27 (T3-Sy).** Base branch is `T3-Sy-remove-dict`, not `master`, because the T3-Sy fork PR (#27) is not yet merged. Re-target to `master` once #27 lands; the diff below is this slice only.

### What this does

Upstream fiorix v4.3.0 already ships the Gx (16777238) and Ro/Rf (TGPP application 4) `<application>` blocks. The trilogy fork's only divergence in `diam/dict/testdata/gx_credit_control.xml` and `tgpp_ro_rf.xml` is a set of 3GPP vendor + standards-track AVP definitions injected into those existing apps. Those move to ccab-owned `diameter-adapter/common/dict`; this PR restores the fork's two source files to **byte-identical vanilla v4.3.0** and regenerates.

**Removed from the fork (moved to ccab):**
- **Gx (11):** Bearer-Control-Mode 1023, Charging-Rule-Report 1018, PCC-Rule-Status 1019, Rule-Failure-Code 1031, Packet-Filter-Content 1059, Packet-Filter-Information 1061, Credit-Management-Status 1082, TGPP-PS-Data-Off-Status 2847, TGPP-SGSN-IPv6-Address 15, IP-CAN-Session-Charging-Scope 2827, Content-Version 552.
- **Ro/Rf (8):** Announcement-Information 3904, Announcement-Identifier 3905, Called-Identity 3916, Called-Identity-Change 3917, Access-Network-Info-Change 4401, Inter-UE-Transfer 3902, FE-Identifier-List 4413, Cellular-Network-Information 3924 (+ two `<rule>` references inside IMS-Information).
- **Ro/Rf rename revert:** the fork had renamed vanilla's `Trunk-Group-Id` / `Incoming-` / `Outgoing-Trunk-Group-Id` (851/852/853) to the uppercase `-ID` spelling; reverted to vanilla. The adapter's uppercase aliases now come from ccab dict.

### How

`diam/dict/testdata/{gx_credit_control,tgpp_ro_rf}.xml` restored to vanilla, then `cd diam && sh autogen.sh` regenerated `commands.go`, `applications.go`, `avp/codes.go`, `dict/default.go`. The `MultimediaAuthentication` deprecated alias (which vanilla appends to `commands.go` after the generated block) is re-added post-autogen. **Content-Version (552)** stays in `avp/codes.go` because vanilla still defines that name in its Rx application.

### Verification

- `diff` of both source XMLs vs vanilla v4.3.0 → **empty**.
- `commands.go` → byte-identical to vanilla; `avp/codes.go` → removed exactly the 18 in-scope constants, no others.
- Regeneration stable (`autogen.sh` twice → no further diff); `gofmt` clean.
- `go test -race ./diam/...` green (only `TestServerClose/sctp` fails — darwin SCTP env limitation, pre-existing on base). No fork test asserted any removed definition.
- All 5 ccab Go modules pass the Gradle test + 100% coverage gate against this tag.

Tag: **`v4.3.0-ccab.9`**.
