### PR TITLE
dict: de-fork Rx (16777236) AVP modifications (DALR T3-Rx-mods)

### DIFF
--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -4981,12 +4981,7 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 
 var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 <diameter>
-
-	<!--
-		3GPP TS 29.214
-		See: https://www.3gpp.org/ftp//Specs/archive/29_series/29.214/29214-g40.zip
-	-->
-	<application id="16777236" type="auth" name="Rx">
+<application id="16777236" type="auth" name="Rx">
         <vendor id="10415" name="TGPP"/>
         <command code="265" short="AA" name="AA">
 			<request>
@@ -5010,7 +5005,7 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="Supported-Features" required="false"/>
 				<rule avp="Reservation-Priority" required="false" max="1"/>
 				<rule avp="Framed-IP-Address" required="false" max="1"/>
-				<rule avp="Framed-IPv6-Prefix" required="false" max="1"/>
+				<rule avp="Framed-Ipv6-Prefix" required="false" max="1"/>
 				<rule avp="Called-Station-Id" required="false" max="1"/>
 				<rule avp="Service-URN" required="false" max="1"/>
 				<rule avp="Sponsored-Connectivity-Data " required="false" max="1"/>
@@ -5073,7 +5068,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="258" short="RA" name="Re-Auth">
 			<request>
 				<rule avp="Session-Id " required="true" max="1"/>
@@ -5138,7 +5132,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="275" short="ST" name="Session-Termination">
 			<request>
 				<rule avp="Session-Id" required="true" max="1"/>
@@ -5192,7 +5185,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="274" short="AS" name="Abort-Session">
 			<request>
 				<rule avp="Session-Id" required="true" max="1"/>
@@ -5373,7 +5365,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Max-Requested-Bandwidth-UL" code="516" vendor-id="10415" must="M,V" may-encrypt="Y">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Extended-Max-Requested-BW-DL" code="554" vendor-id="10415" must="V" may-encrypt="Y">
 			<data type="Unsigned32"/>
 		</avp>
@@ -5708,22 +5699,19 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="2" name="RESTRICT_ACCESS"/>
             		</data>
         	</avp>
-
 		 <avp name="Pre-emption-Capability" code="1047" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="PRE-EMPTION_CAPABILITY_ENABLED"/>
                 		<item code="1" name="PRE-EMPTION_CAPABILITY_DISABLED"/>
             		</data>
         	</avp>
-
 		<avp name="Pre-emption-Vulnerability" code="1048" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="PRE-EMPTION_VULNERABILITY_ENABLED"/>
                 		<item code="1" name="PRE-EMPTION_VULNERABILITY_DISABLED"/>
             		</data>
         	</avp>
-
-		<avp name="Reservation-Priority" code="458" vendor-id="13019" must="V" may-encrypt="Y">
+		<avp name="Reservation-Priority" code="458" vendor-id="10415" must="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="DEFAULT"/>
                 		<item code="1" name="PRIORITY-ONE"/>
@@ -5743,11 +5731,9 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Called-Party-Address" code="832" must="V,M" may-encrypt="N" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
 		<avp name="Requested-Party-Address" code="1251" must="V,M" may-encrypt="N" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
 		 <avp name="Called-Asserted-Identity" code="1250" must="V,M" may-encrypt="N" vendor-id="10415">
         	    	<data type="UTF8String"/>
         	</avp>
@@ -5766,7 +5752,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="9" name="Non-3GPP-5GS"/>
             		</data>
         	</avp>
-
 		<avp name="RAT-Type" code="1032" must="M,V" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="WLAN"/>
@@ -5782,7 +5767,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="2003" name="EHRPD"/>
             		</data>
         	</avp>
-
 		<avp name="Granted-Service-Unit" code="431" must="M" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Tariff-Time-Change" required="false" max="1"/>
@@ -5795,7 +5779,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<!-- *[ AVP ]-->
             		</data>
         	</avp>
-
 		<avp name="Used-Service-Unit" code="446" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Tariff-Change-Usage" required="false" max="1"/>
@@ -5812,11 +5795,9 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		 <avp name="Tariff-Time-Change" code="451" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Time"/>
         	</avp>
-
 		<avp name="CC-Time" code="420" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned32"/>
         	</avp>
-
 		 <avp name="CC-Money" code="413" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Unit-Value" required="true" max="1"/>
@@ -5830,27 +5811,21 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<rule avp="Exponent" required="true" max="1"/>
             		</data>
         	</avp>
-
 		<avp name="Currency-Code" code="425" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Value-Digits" code="447" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Integer64"/>
         	</avp>
-
 		<avp name="Exponent" code="429" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Integer32"/>
         	</avp>
-
 		<avp name="CC-Total-Octets" code="421" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
-
 		 <avp name="CC-Output-Octets" code="414" must="M" may="P" must-not="V" may-encrypt="Y">
         	    	<data type="Unsigned64"/>
         	</avp>
-
 		 <avp name="CC-Service-Specific-Units" code="417" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
@@ -5858,7 +5833,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
         	<avp name="CC-Input-Octets" code="412" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
-
 		<avp name="DRMP" code="301" must-not="V">
             		<data type="Enumerated">
                 		<item code="0" name="PRIORITY_0"/>
@@ -5879,19 +5853,15 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="15" name="PRIORITY_15"/>
             		</data>
         	</avp>
-
 		<avp name="Origin-Host" code="264" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		<avp name="Origin-Realm" code="296" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		<avp name="Destination-Host" code="293" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
         	<avp name="Destination-Realm" code="283" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
@@ -5899,25 +5869,21 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Auth-Application-Id" code="258" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Auth-Session-State" code="277" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Enumerated">
                 		<item code="0" name="STATE_MAINTAINED"/>
                 		<item code="1" name="NO_STATE_MAINTAINED"/>
             		</data>
         	</avp>
-
 		 <avp name="Subscription-Id" code="443" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Subscription-Id-Type" required="true" max="1"/>
                 		<rule avp="Subscription-Id-Data" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="Subscription-Id-Data" code="444" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="Subscription-Id-Type" code="450" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="END_USER_E164"/>
@@ -5926,7 +5892,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="3" name="END_USER_NAI"/>
             		</data>
         	</avp>
-
 		<avp name="OC-Supported-Features" code="621" must-not="V">
             		<data type="Grouped">
                 		<rule avp="Subscription-Id-Type" required="true" max="1"/>
@@ -5949,11 +5914,9 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Feature-List-ID" code="629" must="V" must_not="M" may-encrypt="N" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Feature-List" code="630" must="V" must-not="M" may-encrypt="N" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Framed-IP-Address" code="8" must="M" may="-" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
@@ -5996,26 +5959,21 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Proxy-Host" code="280" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
         	<avp name="Proxy-State" code="33" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="OctetString"/>
         	</avp>
-
 		 <avp name="Route-Record" code="282" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		 <avp name="Result-Code" code="268" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		 <avp name="Experimental-Result" code="297" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Grouped">
                 		<rule avp="Vendor-Id" required="true" max="1"/>
                 		<rule avp="Experimental-Result-Code" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="Experimental-Result-Code" code="298" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
@@ -6023,14 +5981,12 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		 <avp name="AN-GW-Address" code="1050" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Address"/>
         	</avp>
-
 		<avp name="AN-Trusted" code="1503" must="M,V">
             		<data type="Enumerated">
 				<item code="0" name="TRUSTED"/>
                 		<item code="1" name="UNTRUSTED"/>
 			</data>
         	</avp>
-
 		<avp name="NetLoc-Access-Support" code="2824" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Unsigned32"/>
         	</avp>
@@ -6044,22 +6000,18 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<rule avp="AVP" required="false"/>
             		</data>
         	</avp>
-
         	<avp name="OC-Sequence-Number" code="624" must-not="V">
            		<data type="Unsigned64"/>
         	</avp>
-
        	 	<avp name="OC-Validity-Duration" code="625" must-not="V">
             		<data type="Unsigned32"/>
         	</avp>
-
         	<avp name="OC-Report-Type" code="626" must-not="V">
             		<data type="Enumerated">
                 		<item code="0" name="HOST_REPORT"/>
                 		<item code="1" name="REALM_REPORT"/>
             		</data>
         	</avp>
-
         	<avp name="OC-Reduction-Percentage" code="627" must-not="V">
             		<data type="Unsigned32"/>
         	</avp>
@@ -6070,7 +6022,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<rule avp="User-Equipment-Info-Value" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="User-Equipment-Info-Type" code="459" must="-" may="P,M" must-not="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="IMEISV"/>
@@ -6079,11 +6030,9 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
                 		<item code="3" name="MODIFIED_EUI64"/>
             		</data>
         	</avp>
-
         	<avp name="User-Equipment-Info-Value" code="460" must="-" may="P,M" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
-
 		<avp name="Class" code="25" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
@@ -6091,11 +6040,9 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		 <avp name="Error-Message" code="281" must="-" may="P" must-not="V,M" may-encrypt="-">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="Error-Reporting-Host" code="294" must="-" may="P" must-not="V,M" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		 <avp name="Redirect-Host" code="292" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterURI"/>
         	</avp>
@@ -6115,7 +6062,6 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="Redirect-Max-Cache-Time" code="262" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Load" code="650" must-not="V">
          		 <data type="Grouped">
                 		<rule avp="Load-Type" required="false" max="1"/>
@@ -6139,50 +6085,37 @@ var tgpprxXML = `<?xml version="1.0" encoding="UTF-8"?>
 		<avp name="SourceID" code="649" must-not="V">
         	    	<data type="DiameterIdentity"/>
 	        </avp>
-
 		<avp name="User-Location-Info-Time" code="2812" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Time"/>
 	        </avp>
-
-		<avp name="RAN-NAS-Release-Cause" code="2819" vendor-id="10415" must="V" may="P" must-not="M" may-encrypt="Y">
+		<avp name="RAN-NAS-Release-Cause" code="2819" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="OctetString"/>
 	        </avp>
-
 		<avp name="TWAN-Identifier" code="29" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="OctetString"/>
 	        </avp>
-
-
 		<avp name="TCP-Source-Port" code="2843" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Unsigned32"/>
 	        </avp>
-
-
 		<avp name="UDP-Source-Port" code="2806" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Unsigned32"/>
 	        </avp>
-
-
 		<avp name="UE-Local-IP-Address" code="2805" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Address"/>
 	        </avp>
-
 		<avp name="Failed-AVP" code="279" must="M" may="P" must-not="V" may-encrypt="-">
         	    	<data type="Grouped"/>
 	        </avp>
-
-		<avp name="Framed-IPv6-Prefix" code="97" must="M" may-encrypt="Y">
+		<avp name="Framed-Ipv6-Prefix" code="97" must="M" may-encrypt="Y">
             		<data type="OctetString"/>
 	        </avp>
 	
 		<avp name="TGPP-SGSN-MCC-MNC" code="18" must="V"    may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="TGPP-User-Location-Info" code="22" must="V"  may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="OctetString"/>
 	        </avp>
-
    		<avp name="TGPP-MS-TimeZone" code="23" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="OctetString"/>
        </avp>

--- a/diam/dict/testdata/tgpp_rx.xml
+++ b/diam/dict/testdata/tgpp_rx.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <diameter>
-
-	<!--
-		3GPP TS 29.214
-		See: https://www.3gpp.org/ftp//Specs/archive/29_series/29.214/29214-g40.zip
-	-->
-	<application id="16777236" type="auth" name="Rx">
+<application id="16777236" type="auth" name="Rx">
         <vendor id="10415" name="TGPP"/>
         <command code="265" short="AA" name="AA">
 			<request>
@@ -29,7 +24,7 @@
 				<rule avp="Supported-Features" required="false"/>
 				<rule avp="Reservation-Priority" required="false" max="1"/>
 				<rule avp="Framed-IP-Address" required="false" max="1"/>
-				<rule avp="Framed-IPv6-Prefix" required="false" max="1"/>
+				<rule avp="Framed-Ipv6-Prefix" required="false" max="1"/>
 				<rule avp="Called-Station-Id" required="false" max="1"/>
 				<rule avp="Service-URN" required="false" max="1"/>
 				<rule avp="Sponsored-Connectivity-Data " required="false" max="1"/>
@@ -92,7 +87,6 @@
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="258" short="RA" name="Re-Auth">
 			<request>
 				<rule avp="Session-Id " required="true" max="1"/>
@@ -157,7 +151,6 @@
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="275" short="ST" name="Session-Termination">
 			<request>
 				<rule avp="Session-Id" required="true" max="1"/>
@@ -211,7 +204,6 @@
 				<rule avp="AVP" required="false"/>
 			</answer>
 		</command>
-
 		<command code="274" short="AS" name="Abort-Session">
 			<request>
 				<rule avp="Session-Id" required="true" max="1"/>
@@ -392,7 +384,6 @@
 		<avp name="Max-Requested-Bandwidth-UL" code="516" vendor-id="10415" must="M,V" may-encrypt="Y">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Extended-Max-Requested-BW-DL" code="554" vendor-id="10415" must="V" may-encrypt="Y">
 			<data type="Unsigned32"/>
 		</avp>
@@ -727,22 +718,19 @@
                 		<item code="2" name="RESTRICT_ACCESS"/>
             		</data>
         	</avp>
-
 		 <avp name="Pre-emption-Capability" code="1047" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="PRE-EMPTION_CAPABILITY_ENABLED"/>
                 		<item code="1" name="PRE-EMPTION_CAPABILITY_DISABLED"/>
             		</data>
         	</avp>
-
 		<avp name="Pre-emption-Vulnerability" code="1048" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="PRE-EMPTION_VULNERABILITY_ENABLED"/>
                 		<item code="1" name="PRE-EMPTION_VULNERABILITY_DISABLED"/>
             		</data>
         	</avp>
-
-		<avp name="Reservation-Priority" code="458" vendor-id="13019" must="V" may-encrypt="Y">
+		<avp name="Reservation-Priority" code="458" vendor-id="10415" must="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="DEFAULT"/>
                 		<item code="1" name="PRIORITY-ONE"/>
@@ -762,11 +750,9 @@
 		<avp name="Called-Party-Address" code="832" must="V,M" may-encrypt="N" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
 		<avp name="Requested-Party-Address" code="1251" must="V,M" may-encrypt="N" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
 		 <avp name="Called-Asserted-Identity" code="1250" must="V,M" may-encrypt="N" vendor-id="10415">
         	    	<data type="UTF8String"/>
         	</avp>
@@ -785,7 +771,6 @@
                 		<item code="9" name="Non-3GPP-5GS"/>
             		</data>
         	</avp>
-
 		<avp name="RAT-Type" code="1032" must="M,V" may-encrypt="Y" vendor-id="10415">
             		<data type="Enumerated">
                 		<item code="0" name="WLAN"/>
@@ -801,7 +786,6 @@
                 		<item code="2003" name="EHRPD"/>
             		</data>
         	</avp>
-
 		<avp name="Granted-Service-Unit" code="431" must="M" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Tariff-Time-Change" required="false" max="1"/>
@@ -814,7 +798,6 @@
                 		<!-- *[ AVP ]-->
             		</data>
         	</avp>
-
 		<avp name="Used-Service-Unit" code="446" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Tariff-Change-Usage" required="false" max="1"/>
@@ -831,11 +814,9 @@
 		 <avp name="Tariff-Time-Change" code="451" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Time"/>
         	</avp>
-
 		<avp name="CC-Time" code="420" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned32"/>
         	</avp>
-
 		 <avp name="CC-Money" code="413" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Unit-Value" required="true" max="1"/>
@@ -849,27 +830,21 @@
                 		<rule avp="Exponent" required="true" max="1"/>
             		</data>
         	</avp>
-
 		<avp name="Currency-Code" code="425" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Value-Digits" code="447" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Integer64"/>
         	</avp>
-
 		<avp name="Exponent" code="429" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Integer32"/>
         	</avp>
-
 		<avp name="CC-Total-Octets" code="421" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
-
 		 <avp name="CC-Output-Octets" code="414" must="M" may="P" must-not="V" may-encrypt="Y">
         	    	<data type="Unsigned64"/>
         	</avp>
-
 		 <avp name="CC-Service-Specific-Units" code="417" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
@@ -877,7 +852,6 @@
         	<avp name="CC-Input-Octets" code="412" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Unsigned64"/>
         	</avp>
-
 		<avp name="DRMP" code="301" must-not="V">
             		<data type="Enumerated">
                 		<item code="0" name="PRIORITY_0"/>
@@ -898,19 +872,15 @@
                 		<item code="15" name="PRIORITY_15"/>
             		</data>
         	</avp>
-
 		<avp name="Origin-Host" code="264" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		<avp name="Origin-Realm" code="296" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		<avp name="Destination-Host" code="293" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
         	<avp name="Destination-Realm" code="283" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
@@ -918,25 +888,21 @@
 		<avp name="Auth-Application-Id" code="258" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Auth-Session-State" code="277" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Enumerated">
                 		<item code="0" name="STATE_MAINTAINED"/>
                 		<item code="1" name="NO_STATE_MAINTAINED"/>
             		</data>
         	</avp>
-
 		 <avp name="Subscription-Id" code="443" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Grouped">
                 		<rule avp="Subscription-Id-Type" required="true" max="1"/>
                 		<rule avp="Subscription-Id-Data" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="Subscription-Id-Data" code="444" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="Subscription-Id-Type" code="450" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="END_USER_E164"/>
@@ -945,7 +911,6 @@
                 		<item code="3" name="END_USER_NAI"/>
             		</data>
         	</avp>
-
 		<avp name="OC-Supported-Features" code="621" must-not="V">
             		<data type="Grouped">
                 		<rule avp="Subscription-Id-Type" required="true" max="1"/>
@@ -968,11 +933,9 @@
 		<avp name="Feature-List-ID" code="629" must="V" must_not="M" may-encrypt="N" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Feature-List" code="630" must="V" must-not="M" may-encrypt="N" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
-
 		<avp name="Framed-IP-Address" code="8" must="M" may="-" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
@@ -1015,26 +978,21 @@
 		<avp name="Proxy-Host" code="280" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
         	<avp name="Proxy-State" code="33" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="OctetString"/>
         	</avp>
-
 		 <avp name="Route-Record" code="282" must="M" may="-" must-not="P,V" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		 <avp name="Result-Code" code="268" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		 <avp name="Experimental-Result" code="297" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Grouped">
                 		<rule avp="Vendor-Id" required="true" max="1"/>
                 		<rule avp="Experimental-Result-Code" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="Experimental-Result-Code" code="298" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
@@ -1042,14 +1000,12 @@
 		 <avp name="AN-GW-Address" code="1050" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Address"/>
         	</avp>
-
 		<avp name="AN-Trusted" code="1503" must="M,V">
             		<data type="Enumerated">
 				<item code="0" name="TRUSTED"/>
                 		<item code="1" name="UNTRUSTED"/>
 			</data>
         	</avp>
-
 		<avp name="NetLoc-Access-Support" code="2824" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="Unsigned32"/>
         	</avp>
@@ -1063,22 +1019,18 @@
                 		<rule avp="AVP" required="false"/>
             		</data>
         	</avp>
-
         	<avp name="OC-Sequence-Number" code="624" must-not="V">
            		<data type="Unsigned64"/>
         	</avp>
-
        	 	<avp name="OC-Validity-Duration" code="625" must-not="V">
             		<data type="Unsigned32"/>
         	</avp>
-
         	<avp name="OC-Report-Type" code="626" must-not="V">
             		<data type="Enumerated">
                 		<item code="0" name="HOST_REPORT"/>
                 		<item code="1" name="REALM_REPORT"/>
             		</data>
         	</avp>
-
         	<avp name="OC-Reduction-Percentage" code="627" must-not="V">
             		<data type="Unsigned32"/>
         	</avp>
@@ -1089,7 +1041,6 @@
                 		<rule avp="User-Equipment-Info-Value" required="true" max="1"/>
             		</data>
         	</avp>
-
         	<avp name="User-Equipment-Info-Type" code="459" must="-" may="P,M" must-not="V" may-encrypt="Y">
             		<data type="Enumerated">
                 		<item code="0" name="IMEISV"/>
@@ -1098,11 +1049,9 @@
                 		<item code="3" name="MODIFIED_EUI64"/>
             		</data>
         	</avp>
-
         	<avp name="User-Equipment-Info-Value" code="460" must="-" may="P,M" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
-
 		<avp name="Class" code="25" must="M" may="P" must-not="V" may-encrypt="Y">
             		<data type="OctetString"/>
         	</avp>
@@ -1110,11 +1059,9 @@
 		 <avp name="Error-Message" code="281" must="-" may="P" must-not="V,M" may-encrypt="-">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="Error-Reporting-Host" code="294" must="-" may="P" must-not="V,M" may-encrypt="-">
             		<data type="DiameterIdentity"/>
         	</avp>
-
 		 <avp name="Redirect-Host" code="292" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="DiameterURI"/>
         	</avp>
@@ -1134,7 +1081,6 @@
 		<avp name="Redirect-Max-Cache-Time" code="262" must="M" may="P" must-not="V" may-encrypt="-">
             		<data type="Unsigned32"/>
         	</avp>
-
 		<avp name="Load" code="650" must-not="V">
          		 <data type="Grouped">
                 		<rule avp="Load-Type" required="false" max="1"/>
@@ -1158,50 +1104,37 @@
 		<avp name="SourceID" code="649" must-not="V">
         	    	<data type="DiameterIdentity"/>
 	        </avp>
-
 		<avp name="User-Location-Info-Time" code="2812" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Time"/>
 	        </avp>
-
-		<avp name="RAN-NAS-Release-Cause" code="2819" vendor-id="10415" must="V" may="P" must-not="M" may-encrypt="Y">
+		<avp name="RAN-NAS-Release-Cause" code="2819" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="OctetString"/>
 	        </avp>
-
 		<avp name="TWAN-Identifier" code="29" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="OctetString"/>
 	        </avp>
-
-
 		<avp name="TCP-Source-Port" code="2843" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Unsigned32"/>
 	        </avp>
-
-
 		<avp name="UDP-Source-Port" code="2806" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Unsigned32"/>
 	        </avp>
-
-
 		<avp name="UE-Local-IP-Address" code="2805" must="V" may="P" must-not="M" may-encrypt="Y">
         	    	<data type="Address"/>
 	        </avp>
-
 		<avp name="Failed-AVP" code="279" must="M" may="P" must-not="V" may-encrypt="-">
         	    	<data type="Grouped"/>
 	        </avp>
-
-		<avp name="Framed-IPv6-Prefix" code="97" must="M" may-encrypt="Y">
+		<avp name="Framed-Ipv6-Prefix" code="97" must="M" may-encrypt="Y">
             		<data type="OctetString"/>
 	        </avp>
 	
 		<avp name="TGPP-SGSN-MCC-MNC" code="18" must="V"    may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="UTF8String"/>
         	</avp>
-
         	<avp name="TGPP-User-Location-Info" code="22" must="V"  may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="OctetString"/>
 	        </avp>
-
    		<avp name="TGPP-MS-TimeZone" code="23" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             		<data type="OctetString"/>
        </avp>


### PR DESCRIPTION
> ## ⚠️ DO NOT SQUASH / MERGE-COMMIT — FAST-FORWARD ONLY
>
> This PR's head commit carries the release tag **\`v4.3.0-ccab.10\`**. A squash or
> merge-commit from the GitHub UI creates a NEW commit, **orphaning the tag** — which
> poisons the Go module proxy and every ccab \`replace … => v4.3.0-ccab.10\` pin.
>
> **Merge procedure:** \`git checkout <base> && git merge --ff-only T3-Rx-mods-remove-dict\`,
> then remove the \`do-not-merge\` label. This chain is merged base→…→master in order.

## What

Final dict de-fork slice (DALR T3-Rx-mods, ccab #16126). The fork carried three
in-place modifications to fiorix's own Rx (16777236) AVP definitions in
\`diam/dict/testdata/tgpp_rx.xml\`; this reverts all three to byte-identical vanilla
fiorix v4.3.0:

- **Framed-Ipv6-Prefix (97)** — fork renamed it to the uppercase \`Framed-IPv6-Prefix\`.
  Reverted to the vanilla \`Framed-Ipv6-Prefix\`. (The uppercase name the adapter binds
  by avp tag is carried as a base-application alias in ccab \`common/dict\`, ccab #16126.)
- **RAN-NAS-Release-Cause (2819)** — fork added \`vendor-id="10415"\`. Reverted to vanilla
  (no vendor-id).
- **Reservation-Priority (458)** — fork set \`vendor-id="13019"\` (ETSI). Reverted to the
  vanilla \`vendor-id="10415"\`.

## How

\`cp <vanilla>/tgpp_rx.xml <fork>/tgpp_rx.xml\` (restores the whole file, incl. whitespace
and header, to vanilla) → \`cd diam && sh autogen.sh\` regenerates
\`commands.go\`/\`applications.go\`/\`avp/codes.go\`/\`dict/default.go\` → re-add the
\`MultimediaAuthentication\` deprecated alias to \`commands.go\` (autogen drops it; vanilla
appends it post-heredoc).

## Verification

- \`diff <vanilla>/diam/dict/testdata/tgpp_rx.xml diam/dict/testdata/tgpp_rx.xml\` → empty
  (byte-identical). \`commands.go\` and \`applications.go\` identical to vanilla;
  \`avp/codes.go\` and \`dict/default.go\` differ only by the pre-existing T3-base/earlier-slice
  residuals (\`FiveG*\` naming, \`Provider-Id\`), not by anything Rx.
- Regeneration-stable (autogen twice → no new diff). \`gofmt -l\` clean.
- \`go test -race ./diam/...\` green (only \`TestServerClose/sctp\` fails — SCTP unsupported
  on darwin). No fork test asserted the old casing/vendor.

After this slice the fork dictionary reaches full vanilla fiorix v4.3.0 parity (modulo the
T3-base \`Provider-Id\`), completing T3.

Tag: **\`v4.3.0-ccab.10\`** (on the head commit).