### PR TITLE
dict: de-fork base-application Provider-Id (DALR T3-base) [tag v4.3.0-ccab.11]

### DIFF
--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -523,7 +523,6 @@ const (
 	PrioritySharingIndicator                   = 550
 	ProductName                                = 269
 	Prompt                                     = 76
-	ProviderID                                 = 10001
 	ProxyHost                                  = 280
 	ProxyInfo                                  = 284
 	ProxyState                                 = 33

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -564,10 +564,6 @@ var baseXML = `<?xml version="1.0" encoding="UTF-8"?>
 			</data>
 		</avp>
 
-        <avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
-			<data type="OctetString"/>
-		</avp>
-
 
 	</application>
 	<application id="3" type="acct" name="Base Accounting"> <!-- Diameter Base Accounting Messages -->

--- a/diam/dict/testdata/base.xml
+++ b/diam/dict/testdata/base.xml
@@ -522,10 +522,6 @@
 			</data>
 		</avp>
 
-        <avp name="Provider-Id" code="10001" must="M" may="P" must-not="V" may-encrypt="-">
-			<data type="OctetString"/>
-		</avp>
-
 
 	</application>
 	<application id="3" type="acct" name="Base Accounting"> <!-- Diameter Base Accounting Messages -->


### PR DESCRIPTION
## ⚠️ DO NOT SQUASH / DO NOT \`gh pr merge\` — FF-MERGE ONLY (carries release tag \`v4.3.0-ccab.11\`)

**This PR's head commit \`51a8be9\` is tagged \`v4.3.0-ccab.11\`, which ccab go.mod \`replace\` directives pin.** A squash or merge-commit (including `gh pr merge --rebase`) rewrites the commit SHA and **orphans the tag** → poisons the Go module proxy / breaks the ccab pin. This PR must land via an **admin fast-forward merge that preserves \`51a8be9\`** (`git merge --ff-only` then `git push origin master`, or `git push --ff-only`). `gergogera` has *maintain*, not *admin*, on the protected fork master and cannot do this — **@user must perform the FF-merge** (or add gergogera to the master bypass list). Leave the \`do-not-merge\` label until then.

## What
Final dictionary de-fork slice (DALR T3-base). Removes the fork's last custom dictionary divergence: the fork-added base-application AVP **Provider-Id (code 10001)** in \`diam/dict/testdata/base.xml\`'s \`<application id="0">\` block. Vanilla fiorix v4.3.0 has no Provider-Id; the definition is migrated into the ccab-owned \`diameter-adapter/common/dict\` (separate ccab PR), so removing it here is correct.

- \`diam/dict/testdata/base.xml\` — removed the Provider-Id \`<avp>\` block (now byte-identical vanilla).
- Regenerated via \`sh autogen.sh\`: \`diam/dict/default.go\` (loses the baked block) and \`diam/avp/codes.go\` (loses \`ProviderID = 10001\`). \`commands.go\`/\`applications.go\` regenerate identically; the \`MultimediaAuthentication\` deprecated alias is preserved.

## Result: fork dict == vanilla
**After this slice, the entire \`diam/dict/testdata/\` tree is byte-identical to vanilla fiorix v4.3.0** — T3 (custom-dictionary de-fork) is COMPLETE. The only remaining \`avp/codes.go\` residual is the pre-existing \`FiveG*\`/\`X5G*\` (572/573/574) constant-naming divergence, which is unrelated to base.xml and out of scope.

## Verification
- \`base.xml\` + whole \`testdata/\` tree \`diff\` vs vanilla v4.3.0: empty.
- \`go test -race -cover ./diam/...\`: green except the documented \`TestServerClose/sctp\` darwin-skip.
- Full ccab 5-module gradle gate green @ 100% coverage against this tag; local DiameterCerIT green (CEA app set unchanged).

## Stacking
Base = \`T3-Rx-mods-remove-dict\` (fork PR #29, tag \`v4.3.0-ccab.10\`, not yet merged). When #29 FF-merges to master this PR's base auto-retargets to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)