### PR TITLE
dict: revert residual scaffolding to vanilla (DALR T3-leftover) [v4.3.0-ccab.12]

### DIFF
--- a/diam/autogen.sh
+++ b/diam/autogen.sh
@@ -22,7 +22,9 @@ if [ -z "$SED" ]; then
 fi
 
 if [ -z "$SORT_FLAG_IGNORE_CASE" ]; then
-	SORT_FLAG_IGNORE_CASE="-f"
+	if [ "$os" = "Darwin" ]; then
+		SORT_FLAG_IGNORE_CASE="-f"
+	fi
 fi
 
 dict=dict/testdata/*.xml
@@ -102,7 +104,6 @@ cat $dict | "$SED" \
 	-e 's/-Id\([-"s]\)/-ID\1/g' \
 	-e 's/-//g' \
 	-ne 's/.*avp name="\(.*\)" code="\([0-9]*\)".*/\1 = \2/p' \
-	| "$SED" -e 's/^5G/FiveG/' \
 	| "$SED" -e 's/^[0-9]/X&/' \
 	| LC_COLLATE=C sort -u $SORT_FLAG_IGNORE_CASE >> $src
 

--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -244,9 +244,6 @@ const (
 	FinalUnitAction                            = 449
 	FinalUnitIndication                        = 430
 	FirmwareRevision                           = 267
-	FiveGMMCause                               = 573
-	FiveGSMCause                               = 574
-	FiveGSRANNASReleaseCause                   = 572
 	FixedUserLocationInfo                      = 2825
 	FlowDescription                            = 507
 	FlowDirection                              = 1080
@@ -816,5 +813,8 @@ const (
 	VPLMNDynamicAddressAllowed                 = 1432
 	VPLMNLIPAAllowed                           = 1617
 	WirelineUserLocationInfo                   = 578
+	X5GMMCause                                 = 573
+	X5GSMCause                                 = 574
+	X5GSRANNASReleaseCause                     = 572
 	XRES                                       = 1448
 )

--- a/diam/dict/util_test.go
+++ b/diam/dict/util_test.go
@@ -46,7 +46,6 @@ func TestApps(t *testing.T) {
 	if apps[8].ID != 16777252 {
 		t.Fatalf("Unexpected app.ID. Want 16777252, have %d", apps[8].ID)
 	}
-	// 3GPP Swx applications
 	if apps[9].ID != 16777265 {
 		t.Fatalf("Unexpected app.ID. Want 16777265, have %d", apps[9].ID)
 	}


### PR DESCRIPTION
## ⚠️ FF-MERGE ONLY — DO NOT SQUASH / DO NOT MERGE-COMMIT

This PR carries release tag **`v4.3.0-ccab.12`** on its head commit `a493fcc`. A squash or merge-commit **orphans the tag**, which poisons the Go module proxy and every ccab `replace` pin. Merge only via `git merge --ff-only`, then remove the `do-not-merge` label. Stacked on #30 (T3-base).

## What
Reverts the three residual fork edits the atomic T3 dict slices left behind, so the fork is byte-identical to vanilla fiorix v4.3.0 outside the intentionally-kept handshake hooks (and the separately-tracked `parseAvpTag` / CEA-PCRF residues, trilogy-group/ccab#16147 / trilogy-group/ccab#16148):

- **`diam/autogen.sh`** — restore the `Darwin`-guarded `SORT_FLAG_IGNORE_CASE`; drop the `s/^5G/FiveG/` sed stage.
- **`diam/avp/codes.go`** — `FiveG{MM,SM,SRANNAS}Cause` revert to vanilla `X5G*` (a pure artifact of the autogen sed; no code references the `FiveG*` names).
- **`diam/dict/util_test.go`** — drop the stray `// 3GPP Swx applications` comment.

## Result
After this, the full fork-vs-vanilla diff is **only** the kept hooks (`sm/`), `reflect.go` (parseAvpTag residue), the CEA-PCRF logic in `cer.go`/`sm.go`, and `go.mod`. All generated files (commands.go, applications.go, avp/codes.go, dict/default.go) are == vanilla v4.3.0.

## Validation
`go build ./...` + `go test ./dict/... ./avp/... ./sm/...` green.

Refs trilogy-group/ccab#16093