### PR TITLE
sm: remove fork CEA advertised-app filter (DALR ccab#16148, tag v4.3.0-ccab.13)

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -151,9 +151,6 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 		a.AddAVP(cer.OriginStateID)
 	}
 	for _, app := range sm.supportedApps {
-		if !ceaAdvertisedApps[app.ID] {
-			continue
-		}
 		var typ uint32
 		switch app.AppType {
 		case "auth":
@@ -183,16 +180,6 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 
 	_, err = a.WriteTo(c)
 	return err
-}
-
-// ceaAdvertisedApps is the set of applications this adapter supports and
-// therefore advertises in the CEA; every other application in the dictionary
-// is omitted.
-var ceaAdvertisedApps = map[uint32]bool{
-	diam.CHARGING_CONTROL_APP_ID:    true, // Gy
-	diam.RX_APP_ID:                  true, // Rx
-	diam.GX_CHARGING_CONTROL_APP_ID: true, // Gx
-	diam.DIAMETER_SY_APP_ID:         true, // Sy
 }
 
 // requestsOnlyPcrfApps reports whether the CER requested applications and every

--- a/diam/sm/cer_cea_pcrf_test.go
+++ b/diam/sm/cer_cea_pcrf_test.go
@@ -28,31 +28,6 @@ var pcrfServerSettings = &Settings{
 	PcrfRealm:        "pcrf-realm.example.com",
 }
 
-// advertisedAppIDs collects every application id advertised in a CEA, both the
-// top-level Auth/Acct-Application-Id AVPs and the ones nested inside grouped
-// Vendor-Specific-Application-Id AVPs.
-func advertisedAppIDs(t *testing.T, m *diam.Message) map[uint32]bool {
-	t.Helper()
-	ids := map[uint32]bool{}
-	for _, a := range m.AVP {
-		switch a.Code {
-		case avp.AuthApplicationID, avp.AcctApplicationID:
-			ids[uint32(a.Data.(datatype.Unsigned32))] = true
-		case avp.VendorSpecificApplicationID:
-			grouped, ok := a.Data.(*diam.GroupedAVP)
-			if !ok {
-				continue
-			}
-			for _, inner := range grouped.AVP {
-				if inner.Code == avp.AuthApplicationID || inner.Code == avp.AcctApplicationID {
-					ids[uint32(inner.Data.(datatype.Unsigned32))] = true
-				}
-			}
-		}
-	}
-	return ids
-}
-
 // originIdentity returns the Origin-Host/Origin-Realm advertised in a CEA.
 func originIdentity(t *testing.T, m *diam.Message) (string, string) {
 	t.Helper()
@@ -109,36 +84,6 @@ func exchangeCER(t *testing.T, settings *Settings, appIDs ...uint32) *diam.Messa
 		t.Fatal("No CEA received")
 	}
 	return nil
-}
-
-// TestCEA_AdvertisesOnlySupportedApps verifies that the CEA advertises only the
-// applications this adapter supports (Gy, Rx, Gx), even though the loaded
-// dictionary contains more applications (NASREQ, Base Accounting, S6a, SWx).
-func TestCEA_AdvertisesOnlySupportedApps(t *testing.T) {
-	cea := exchangeCER(t, pcrfServerSettings, diam.GX_CHARGING_CONTROL_APP_ID)
-	if !testResultCode(cea, diam.Success) {
-		t.Fatalf("Unexpected result code.\n%s", cea)
-	}
-
-	got := advertisedAppIDs(t, cea)
-	want := map[uint32]bool{
-		diam.CHARGING_CONTROL_APP_ID:    true,
-		diam.RX_APP_ID:                  true,
-		diam.GX_CHARGING_CONTROL_APP_ID: true,
-	}
-	for id := range want {
-		if !got[id] {
-			t.Errorf("CEA missing supported application id %d", id)
-		}
-	}
-	for id := range got {
-		if !want[id] {
-			t.Errorf("CEA advertises unsupported application id %d", id)
-		}
-	}
-	if len(got) != len(want) {
-		t.Errorf("CEA advertised %d apps, want %d (%v)", len(got), len(want), got)
-	}
 }
 
 // TestCEA_PcrfIdentitySelection verifies the Origin-Host/Origin-Realm chosen in

--- a/diam/sm/sctp_test.go
+++ b/diam/sm/sctp_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/fiorix/go-diameter/v4/diam/datatype"
 )
 
 func requireSCTP(t *testing.T) {
@@ -37,13 +36,5 @@ func testClient_Handshake_CustomIP_SCTP(t *testing.T) {
 // completed and that the RAR handler has context from the peer.
 func TestStateMachineSCTP(t *testing.T) {
 	requireSCTP(t)
-	// SCTP sockets are multi-homed: on a host with a non-loopback address
-	// (e.g. CI runners) getLocalAddresses() prefers the real address over
-	// loopback, so the auto-detected Host-IP-Address would not match the
-	// loopback value testStateMachine's expected CEA asserts. Pin it to
-	// loopback for this run (a local copy, so the shared serverSettings and
-	// the TCP test are untouched).
-	settings := *serverSettings
-	settings.HostIPAddresses = []datatype.Address{localhostAddress}
-	testStateMachine(t, "sctp", &settings)
+	testStateMachine(t, "sctp")
 }

--- a/diam/sm/sm_test.go
+++ b/diam/sm/sm_test.go
@@ -5,8 +5,6 @@
 package sm
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,15 +30,15 @@ func testResultCode(m *diam.Message, want uint32) bool {
 // sends a Re-Auth-Request message to ensure the handshake was
 // completed and that the RAR handler has context from the peer.
 func TestStateMachineTCP(t *testing.T) {
-	testStateMachine(t, "tcp", serverSettings)
+	testStateMachine(t, "tcp")
 }
 
-// / TestStateMachine establishes a connection with a test server and
+/// TestStateMachine establishes a connection with a test server and
 // sends a Re-Auth-Request message to ensure the handshake was
 // completed and that the RAR handler has context from the peer.
-func testStateMachine(t *testing.T, network string, settings *Settings) {
-	sm := New(settings)
-	if sm.Settings() != settings {
+func testStateMachine(t *testing.T, network string) {
+	sm := New(serverSettings)
+	if sm.Settings() != serverSettings {
 		t.Fatal("Invalid settings")
 	}
 	srv := diamtest.NewServerNetwork(network, sm, dict.Default)
@@ -100,42 +98,6 @@ func testStateMachine(t *testing.T, network string, settings *Settings) {
 		if !testResultCode(resp, diam.Success) {
 			t.Fatalf("Unexpected result code.\n%s", resp)
 		}
-
-		expectedCea := strings.TrimSpace(fmt.Sprintf(`
-Capabilities-Exchange-Answer (CEA)
-{Code:257,Flags:0x0,Version:0x1,Length:272,ApplicationId:1001,HopByHopId:0x%x,EndToEndId:0x%x}
-	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
-	Origin-Host {Code:264,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{srv},Padding:1}
-	Origin-Realm {Code:296,Flags:0x40,Length:12,VendorId:0,Value:DiameterIdentity{test},Padding:0}
-	Host-IP-Address {Code:257,Flags:0x40,Length:16,VendorId:0,Value:Address{127.0.0.1},Padding:2}
-	Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{13}}
-	Product-Name {Code:269,Flags:0x0,Length:20,VendorId:0,Value:UTF8String{go-diameter},Padding:1}
-	Origin-State-Id {Code:278,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1}}
-	Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{4}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777238}},
-	}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{4}},
-	}}
-	Supported-Vendor-Id {Code:265,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}}
-	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
-		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
-		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777236}},
-	}}
-	Firmware-Revision {Code:267,Flags:0x0,Length:12,VendorId:0,Value:Unsigned32{1}}
-
-			`, resp.Header.HopByHopID, resp.Header.EndToEndID))
-		actualCea := strings.TrimSpace(resp.String())
-
-		if expectedCea != actualCea {
-			t.Errorf("CEA is not as expected. Actual CEA: \n %s \n Expected CEA %s", actualCea, expectedCea)
-		}
-
 	case err := <-sm.ErrorReports():
 		t.Fatal(err)
 	case err := <-mux.ErrorReports():


### PR DESCRIPTION
_Re-created against `master` — supersedes #32, which auto-closed when its base branch `T3-leftover-revert-scaffolding` was merged & deleted (the prior DALR T3 slices landed on master). Same head commit, same tag v4.3.0-ccab.13; this branch is exactly one fast-forwardable commit ahead of master._


> ## ⚠️ DO NOT SQUASH / DO NOT "MERGE COMMIT"
> This PR carries release tag **`v4.3.0-ccab.13`** on its head commit. The ccab
> diameter-adapter pins the fork by that tag. A squash or merge-commit merge
> **orphans the tag** (moves history off the tagged commit) → poisons the Go
> module proxy and the ccab `replace` pin.
> **Merge only with `git merge --ff-only`, then remove the `do-not-merge` label.**

## What

Removes the fork-only CEA **advertised-application filter** from `successCEA`,
restoring that loop to upstream fiorix `v4.3.0`.

The fork's `ceaAdvertisedApps` allowlist (fork PR #21, eng-maint #21086) filtered
the CEA's advertised app set to the four supported apps. That belongs on the
**consuming side**: the ccab diameter-adapter now hands the state machine a
dedicated advertise dictionary (`sm.Settings.Dict`) holding exactly those apps,
so `PrepareSupportedApps` produces the right set with no runtime filter. Inbound
messages keep decoding with the full `dict.Default` (`diam.Server.Dict`), so
NASREQ stays loaded as the Gx decode-parent without being advertised.

See ccab #16148 for the full rationale and the advertise/decode dictionary
separation.

## Changes

- `diam/sm/cer.go`: removed the `ceaAdvertisedApps` map and the
  `if !ceaAdvertisedApps[app.ID] { continue }` guard. `successCEA`'s app loop is
  now **byte-identical to upstream fiorix v4.3.0**.
- `diam/sm/cer_cea_pcrf_test.go`: removed `TestCEA_AdvertisesOnlySupportedApps`
  (it tested the removed filter) + its `advertisedAppIDs` helper. Kept the PCRF
  identity tests (those cover ccab #16153, still in the fork for now).
- `diam/sm/sm_test.go`, `diam/sm/sctp_test.go`: reverted to **vanilla v4.3.0**.
  The fork-only byte-exact CEA golden (and the SCTP Host-IP pinning that existed
  only to satisfy it) are dropped — that byte-exact coverage is owned by the ccab
  DA server (`cer_cea_capabilities_test.go`), asserted against the real adapter
  dictionary.

## Out of scope (still fork divergence, tracked separately)

- `Settings.PcrfHost/PcrfRealm` + `requestsOnlyPcrfApps` identity selection →
  ccab #16153.
- `OnCEA`/`OnDWA` server hooks → DALR T1.

## Verification

- `go test ./diam/sm/...` green.
- Fork diff vs `v4.3.0` for `diam/sm/` is now only the remaining DALR divergence
  (T1 hooks, #16153 PCRF block, #16122 CEA peer-capability fields). The
  app-filter is fully gone.
- Consumed + verified by ccab #16148: 100% Go coverage gate on the adapter, the
  byte-exact CEA reproduced unchanged, and DiameterCerIT green end-to-end
  (with a negative test proving the advertise dictionary is load-bearing).

Part of DALR (milestone trilogy-group/ccab#286, trilogy-group/ccab#16148).
Tag: **v4.3.0-ccab.13**.
